### PR TITLE
fix(security): strip IPv6 brackets in SSRF validation (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.4] — 2026-04-05
+
+### Fixed
+- **CRITICAL SSRF bypass**: `isBlockedHost` now strips brackets from IPv6 hostnames before calling `net.isIPv6()` — previously `URL.hostname` returned bracketed addresses (e.g. `[::1]`) which `isIPv6` rejected, making the entire IPv6 validation branch unreachable (closes #15)
+
 ## [1.6.3] — 2026-04-03
 
 ### Added

--- a/src/client.ts
+++ b/src/client.ts
@@ -46,12 +46,6 @@ import type {
   CreateConditionalOrderParams,
   PortfolioPnl,
   RunBacktestParams,
-  Backtest,
-  ConditionalOrder,
-  CreateAlertParams,
-  CreateConditionalOrderParams,
-  PortfolioPnl,
-  RunBacktestParams,
 } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://localhost:3002';
@@ -113,10 +107,11 @@ function isBlockedHost(hostname: string): boolean {
     return false;
   }
 
-  // IPv6 checks
-  if (isIPv6(host)) {
-    // Normalise by removing surrounding brackets (URL-style) just in case.
-    const addr = host.replace(/^\[|\]$/g, '').toLowerCase();
+  // IPv6 checks — strip brackets first because URL.hostname returns
+  // bracketed IPv6 (e.g. "[::1]") and net.isIPv6 requires bare addresses.
+  const bareHost = host.replace(/^\[|\]$/g, '');
+  if (isIPv6(bareHost)) {
+    const addr = bareHost.toLowerCase();
 
     // ::1 (loopback)
     if (addr === '::1') return true;


### PR DESCRIPTION
## What changed

`isBlockedHost` now strips brackets from IPv6 hostnames **before** calling `net.isIPv6()`. Previously, `URL.hostname` returned bracketed addresses (e.g. `[::1]`) which `isIPv6` rejected as non-IPv6, making the entire IPv6 validation branch unreachable. All IPv6 SSRF vectors (loopback, link-local, unique-local, IPv4-mapped) passed validation unblocked.

Also removed duplicate type imports that prevented the build from succeeding.

## Quality gates
- `npm run lint` ✅
- `npm run build` ✅

closes #15