### PR TITLE
fix(compat): align SDK with platform contracts; fix SSRF IPv6 (closes #15, #40, #41, #42, #46, #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.6.4] — 2026-04-05
+
+### Fixed
+- **CRITICAL SSRF bypass**: `isBlockedHost` now strips brackets from IPv6 hostnames before calling `net.isIPv6()` — previously `URL.hostname` returned bracketed addresses making the entire IPv6 validation branch unreachable (closes #15)
+- **BREAKING**: `aiQuery()` sends `{ question }` instead of `{ query }` to match platform `AiQueryDto` (closes #46)
+- **BREAKING**: `RunBacktestParams` uses `dateRangeStart`/`dateRangeEnd` instead of `startDate`/`endDate` to match platform (closes #47)
+- **BREAKING**: `WebhookEvent` values reverted from SCREAMING_SNAKE_CASE to dot.notation to match actual platform events (closes #42)
+- **BREAKING**: `createStrategyFromDescription()` sends `{ query }` instead of `{ description }` to match platform (closes #40)
+- **BREAKING**: `startStrategy()` sends uppercase `"LIVE"`/`"PAPER"` mode values to match platform (closes #41)
+- Removed duplicate type imports that prevented build
+
 ## [1.6.3] — 2026-04-03
 
 ### Added

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,10 +107,11 @@ function isBlockedHost(hostname: string): boolean {
     return false;
   }
 
-  // IPv6 checks
-  if (isIPv6(host)) {
-    // Normalise by removing surrounding brackets (URL-style) just in case.
-    const addr = host.replace(/^\[|\]$/g, '').toLowerCase();
+  // IPv6 checks — strip brackets first because URL.hostname returns
+  // bracketed IPv6 (e.g. "[::1]") and net.isIPv6 requires bare addresses.
+  const bareHost = host.replace(/^\[|\]$/g, '');
+  if (isIPv6(bareHost)) {
+    const addr = bareHost.toLowerCase();
 
     // ::1 (loopback)
     if (addr === '::1') return true;
@@ -281,7 +282,9 @@ export class PolyforgeClient {
     description: string;
     marketId?: string;
   }): Promise<Strategy> {
-    return this.request('POST', '/api/v1/strategies/from-description', { body: params });
+    return this.request('POST', '/api/v1/strategies/from-description', {
+      body: { query: params.description, ...(params.marketId !== undefined && { marketId: params.marketId }) },
+    });
   }
 
   /**
@@ -289,7 +292,7 @@ export class PolyforgeClient {
    */
   async startStrategy(id: string, mode: 'live' | 'paper' = 'paper'): Promise<Strategy> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/start`, {
-      body: { mode },
+      body: { mode: mode.toUpperCase() },
     });
   }
 
@@ -490,7 +493,7 @@ export class PolyforgeClient {
    * Ask the Polyforge AI assistant a natural-language question.
    */
   async aiQuery(query: string): Promise<AiQueryResponse> {
-    return this.request('POST', '/api/v1/ai/query', { body: { query } });
+    return this.request('POST', '/api/v1/ai/query', { body: { question: query } });
   }
 
   // ── Direct Trading ────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,14 +3,14 @@
 export type StrategyStatus = 'IDLE' | 'RUNNING' | 'PAUSED' | 'PAPER';
 
 export type WebhookEvent =
-  | 'ORDER_FILLED'
-  | 'STRATEGY_ERROR'
-  | 'WHALE_TRADE'
-  | 'NEWS_SIGNAL'
-  | 'BACKTEST_COMPLETE'
-  | 'DAILY_LOSS_LIMIT'
-  | 'MARKET_RESOLVED'
-  | 'PRICE_ALERT';
+  | 'order.filled'
+  | 'strategy.error'
+  | 'whale.trade'
+  | 'news.signal'
+  | 'backtest.complete'
+  | 'daily.loss.limit'
+  | 'market.resolved'
+  | 'price.alert';
 
 export type OrderSide = 'BUY' | 'SELL';
 export type OrderType = 'MARKET' | 'LIMIT' | 'STOP' | 'STOP_LIMIT';
@@ -467,8 +467,8 @@ export interface Backtest {
 
 export interface RunBacktestParams {
   strategyId: string;
-  startDate: string;
-  endDate: string;
+  dateRangeStart: string;
+  dateRangeEnd: string;
   initialBalance?: number;
 }
 


### PR DESCRIPTION
## What changed

### Security
- **CRITICAL**: Strip brackets from IPv6 hostnames before `isIPv6()` check — entire IPv6 SSRF validation was unreachable (#15)

### Compatibility
- `aiQuery()`: `query` → `question` (#46)
- `RunBacktestParams`: `startDate`/`endDate` → `dateRangeStart`/`dateRangeEnd` (#47)
- `WebhookEvent`: SCREAMING_SNAKE_CASE → dot.notation (#42)
- `createStrategyFromDescription()`: `description` → `query` (#40)
- `startStrategy()`: lowercase → uppercase LIVE/PAPER (#41)
- Removed duplicate type imports that broke build

## Quality gates
- `npm run lint` ✅
- `npm run build` ✅

closes #15, closes #40, closes #41, closes #42, closes #46, closes #47