### PR TITLE
fix(security): production URL, API key guards, financial validation, stream timeout (closes #34, #35, #38, #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.5] — 2026-04-12
+
+### Security
+- **Default base URL changed to production** — `https://localhost:3002` → `https://api.polyforge.app`; prevents TLS failures that encourage `NODE_TLS_REJECT_UNAUTHORIZED=0` workarounds (closes #44)
+- **API key serialisation guards** — added `toJSON()` and `[Symbol.for('nodejs.util.inspect.custom')]()` to `PolyforgeClient` to prevent API key leakage via `JSON.stringify()` or `util.inspect()` (closes #38)
+- **Financial parameter validation** — `placeOrder()`, `placeSmartOrder()`, `provideLiquidity()` now validate that size/price/spread/totalSize are finite positive numbers before sending to the API; rejects `NaN`, `Infinity`, negative, and zero values (closes #34)
+- **Separate stream timeout** — added `streamTimeout` option (default: 24 hours) for SSE streams; `watchStrategy()` no longer killed by the 15-second request timeout (closes #35)
+
 ## [1.6.4] — 2026-04-05
 
 ### Fixed

--- a/src/client.ts
+++ b/src/client.ts
@@ -48,8 +48,9 @@ import type {
   RunBacktestParams,
 } from './types.js';
 
-const DEFAULT_BASE_URL = 'https://localhost:3002';
+const DEFAULT_BASE_URL = 'https://api.polyforge.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_STREAM_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours for long-lived SSE streams
 
 /**
  * Expand a compressed IPv6 address into its full 8-group colon-hex form.
@@ -154,6 +155,7 @@ export class PolyforgeClient {
   private readonly baseUrl: string;
   private readonly apiKey: string;
   private readonly timeout: number;
+  private readonly streamTimeout: number;
 
   constructor(options: PolyforgeClientOptions) {
     if (!options.apiKey) {
@@ -162,6 +164,7 @@ export class PolyforgeClient {
     this.baseUrl = (options.apiUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.apiKey = options.apiKey;
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.streamTimeout = options.streamTimeout ?? DEFAULT_STREAM_TIMEOUT_MS;
 
     // Reject non-HTTPS URLs for non-localhost hosts to prevent credential leakage
     const parsed = new URL(this.baseUrl);
@@ -171,6 +174,27 @@ export class PolyforgeClient {
       parsed.hostname !== '127.0.0.1'
     ) {
       throw new Error('Non-localhost API URLs must use HTTPS');
+    }
+  }
+
+  /** Prevent API key from leaking via JSON.stringify(client). */
+  toJSON(): Record<string, unknown> {
+    return { baseUrl: this.baseUrl };
+  }
+
+  /** Prevent API key from leaking via util.inspect(client) or console.log(client). */
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
+    return `PolyforgeClient { baseUrl: '${this.baseUrl}', apiKey: '[REDACTED]' }`;
+  }
+
+  // ── Financial parameter validation ──────────────────────────────────────
+
+  private validateFinancialParam(name: string, value: number, allowZero = false): void {
+    if (!Number.isFinite(value)) {
+      throw new PolyforgeError({ status: 0, code: 'VALIDATION_ERROR', message: `${name} must be a finite number` });
+    }
+    if (allowZero ? value < 0 : value <= 0) {
+      throw new PolyforgeError({ status: 0, code: 'VALIDATION_ERROR', message: `${name} must be ${allowZero ? 'non-negative' : 'positive'}` });
     }
   }
 
@@ -502,6 +526,8 @@ export class PolyforgeClient {
    * Place a direct buy or sell order on a prediction market.
    */
   async placeOrder(params: PlaceOrderParams): Promise<PlaceOrderResponse> {
+    this.validateFinancialParam('size', params.size);
+    this.validateFinancialParam('price', params.price);
     return this.request<PlaceOrderResponse>('POST', '/api/v1/orders/place', { body: params });
   }
 
@@ -557,6 +583,7 @@ export class PolyforgeClient {
    * Place an advanced smart order (TWAP, DCA, BRACKET, or OCO).
    */
   async placeSmartOrder(params: PlaceSmartOrderParams): Promise<PlaceSmartOrderResponse> {
+    this.validateFinancialParam('totalSize', params.totalSize);
     return this.request('POST', '/api/v1/orders/smart', { body: params });
   }
 
@@ -628,6 +655,8 @@ export class PolyforgeClient {
    * Provide liquidity by placing two-sided quotes on a market token.
    */
   async provideLiquidity(params: ProvideLiquidityParams): Promise<LpPosition> {
+    this.validateFinancialParam('spread', params.spread);
+    this.validateFinancialParam('size', params.size);
     return this.request('POST', '/api/v1/lp/provide', { body: params });
   }
 
@@ -657,7 +686,7 @@ export class PolyforgeClient {
   ): AsyncGenerator<StrategyEvent> {
     const url = `${this.baseUrl}/api/v1/strategies/${encodeURIComponent(id)}/events`;
     // Merge user-provided signal with a timeout signal to prevent indefinite hangs
-    const timeoutSignal = AbortSignal.timeout(this.timeout);
+    const timeoutSignal = AbortSignal.timeout(this.streamTimeout);
     const combinedSignal = signal
       ? AbortSignal.any([signal, timeoutSignal])
       : timeoutSignal;

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,5 +521,8 @@ export interface PortfolioPnl {
 export interface PolyforgeClientOptions {
   apiUrl?: string;
   apiKey: string;
+  /** Timeout for regular API requests in milliseconds (default: 15000). */
   timeout?: number;
+  /** Timeout for SSE streams in milliseconds (default: 24 hours). */
+  streamTimeout?: number;
 }


### PR DESCRIPTION
## What changed\n\n### Default base URL changed to production (closes #44)\n`https://localhost:3002` → `https://api.polyforge.app`. Prevents TLS failures that encourage unsafe `NODE_TLS_REJECT_UNAUTHORIZED=0` workarounds.\n\n### API key serialisation guards (closes #38)\nAdded `toJSON()` and `[Symbol.for('nodejs.util.inspect.custom')]()` to `PolyforgeClient`. Prevents API key leakage via `JSON.stringify(client)` or `util.inspect(client)` / `console.log(client)`. The Rust SDK already has this via `secrecy::SecretBox` — this brings the TS SDK to parity.\n\n### Financial parameter validation (closes #34)\nAdded `validateFinancialParam()` that rejects `NaN`, `Infinity`, negative, and zero values. Applied to:\n- `placeOrder()` — validates `size` and `price`\n- `placeSmartOrder()` — validates `totalSize`\n- `provideLiquidity()` — validates `spread` and `size`\n\nThrows `PolyforgeError` with code `VALIDATION_ERROR` for invalid values.\n\n### Separate stream timeout (closes #35)\nAdded `streamTimeout` option to `PolyforgeClientOptions` (default: 24 hours). `watchStrategy()` now uses `this.streamTimeout` instead of `this.timeout` (15s), preventing SSE streams from being silently killed after 15 seconds.\n\n## Quality gates\n- `npm run build` — verified via patch script\n- CHANGELOG.md updated\n\ncloses #34, closes #35, closes #38, closes #44