### PR TITLE
fix(security): harden CI runners and pin vite >=8.0.5 for CVEs (closes #68, closes #69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Build & Test
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.4] — 2026-04-08
+
+### Security
+- Switch CI from self-hosted to GitHub-hosted runners (`ubuntu-latest`) and add `permissions: contents: read` to prevent arbitrary code execution from fork PRs (closes #69)
+- Pin `vite` to `>=8.0.5` via npm overrides to fix 3 path traversal and file read CVEs: GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583 (closes #68)
+
 ## [1.6.3] — 2026-04-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "@types/node": "^20.11.0",
     "typescript": "^5.4.0",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "vite": ">=8.0.5"
   }
 }


### PR DESCRIPTION
## What changed

1. Switched CI from self-hosted to GitHub-hosted runners (`ubuntu-latest`) and added `permissions: contents: read` to prevent arbitrary code execution from fork PRs
2. Pinned `vite` to `>=8.0.5` via npm overrides to fix 3 CVEs (path traversal, fs.deny bypass, arbitrary file read): GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583

closes #68
closes #69