### PR TITLE
fix(types): replace StrategyEventType string catch-all with runtime validation (closes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## [Unreleased]
 
 ### Security
+- **StrategyEventType**: replace `| string` catch-all with `| (string & {})` to preserve TypeScript autocomplete; add `KNOWN_STRATEGY_EVENTS` set and runtime `console.warn` for unrecognized SSE event types (closes #80)
+
+### Security
 - **CI**: switch from self-hosted runner to `ubuntu-latest` for `pull_request` events and add `permissions: contents: read` to restrict GITHUB_TOKEN scope (closes #69)
 - **deps**: add npm `overrides` to pin `vite >= 8.0.5`, fixing 3 HIGH advisories (GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583) in transitive vitest dependency (closes #68)
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { PolyforgeClient } from '../client';
 import { PolyforgeError } from '../errors';
+import { KNOWN_STRATEGY_EVENTS } from '../types';
 
 describe('PolyforgeClient', () => {
   describe('constructor', () => {
@@ -146,6 +147,27 @@ describe('PolyforgeError', () => {
 
       expect(error.status).toBe(503);
       expect(error.code).toBe('SERVICE_UNAVAILABLE');
+    });
+  });
+
+  describe('KNOWN_STRATEGY_EVENTS', () => {
+    it('should contain all documented event types', () => {
+      const expected = [
+        'CONNECTED', 'STRATEGY_STARTED', 'STRATEGY_STOPPED',
+        'STRATEGY_PAUSED', 'STRATEGY_RESUMED', 'STRATEGY_ERROR',
+        'ORDER_PLACED', 'ORDER_SUBMITTED', 'ORDER_FILLED',
+        'ORDER_PARTIAL', 'ORDER_CANCELLED', 'ORDER_FAILED', 'ORDER_ERROR',
+        'BACKTEST_PROGRESS', 'BACKTEST_COMPLETED', 'BACKTEST_FAILED',
+      ];
+      for (const type of expected) {
+        expect(KNOWN_STRATEGY_EVENTS.has(type)).toBe(true);
+      }
+      expect(KNOWN_STRATEGY_EVENTS.size).toBe(expected.length);
+    });
+
+    it('should not contain unknown event types', () => {
+      expect(KNOWN_STRATEGY_EVENTS.has('UNKNOWN_TYPE')).toBe(false);
+      expect(KNOWN_STRATEGY_EVENTS.has('')).toBe(false);
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,6 +47,7 @@ import type {
   PortfolioPnl,
   RunBacktestParams,
 } from './types.js';
+import { KNOWN_STRATEGY_EVENTS } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://api.polyforge.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -743,6 +744,9 @@ export class PolyforgeClient {
             const parsed = JSON.parse(raw);
             // Validate expected fields exist before yielding
             if (typeof parsed.type !== 'string') continue;
+            if (!KNOWN_STRATEGY_EVENTS.has(parsed.type)) {
+              console.warn(`[polyforge-sdk] Unknown strategy event type: "${parsed.type}"`);
+            }
             yield parsed as StrategyEvent;
           } catch {
             // skip malformed frame

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { PolyforgeClient } from './client.js';
 export { PolyforgeError } from './errors.js';
+export { KNOWN_STRATEGY_EVENTS } from './types.js';
 export type {
   AiQueryResponse,
   Alert,

--- a/src/types.ts
+++ b/src/types.ts
@@ -282,7 +282,19 @@ export type StrategyEventType =
   | 'BACKTEST_PROGRESS'
   | 'BACKTEST_COMPLETED'
   | 'BACKTEST_FAILED'
-  | string;
+  | (string & {}); // Allows unknown server event types while preserving autocomplete
+
+/**
+ * Set of known strategy event types for runtime validation.
+ * Events not in this set are still yielded but trigger a console warning.
+ */
+export const KNOWN_STRATEGY_EVENTS: ReadonlySet<string> = new Set<StrategyEventType>([
+  'CONNECTED', 'STRATEGY_STARTED', 'STRATEGY_STOPPED',
+  'STRATEGY_PAUSED', 'STRATEGY_RESUMED', 'STRATEGY_ERROR',
+  'ORDER_PLACED', 'ORDER_SUBMITTED', 'ORDER_FILLED',
+  'ORDER_PARTIAL', 'ORDER_CANCELLED', 'ORDER_FAILED', 'ORDER_ERROR',
+  'BACKTEST_PROGRESS', 'BACKTEST_COMPLETED', 'BACKTEST_FAILED',
+]);
 
 /** A single event received from the strategy execution SSE stream. */
 export interface StrategyEvent {


### PR DESCRIPTION
## Summary
- Replace `| string` catch-all on `StrategyEventType` with `| (string & {})` — preserves TypeScript autocomplete for known event types while still accepting unknown server events
- Add `KNOWN_STRATEGY_EVENTS` ReadonlySet for runtime validation
- Add `console.warn` in `watchStrategy()` SSE parser for unrecognized event types
- Export `KNOWN_STRATEGY_EVENTS` from package index for consumer use

## Problem
The `| string` at the end of the `StrategyEventType` union widened the entire type to `string`, defeating TypeScript's type safety. Any value passed type-checking, and unrecognized server events were silently propagated without warning.

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [x] All 17 tests pass (2 new tests for KNOWN_STRATEGY_EVENTS)
- [x] Build succeeds

closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)