### PR TITLE
fix(compat): correct 4 breaking request payload regressions (closes #84, #85, #86, #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.8] — 2026-04-13
+
+### Fixed
+- **BREAKING** `aiQuery()`: send `{ query }` instead of `{ question }` to match platform `AiQueryDto` — AI queries were returning HTTP 400 (closes #84, regression of #46)
+- **BREAKING** `createStrategyFromDescription()`: send `{ description }` instead of `{ query }` to match platform `CreateFromDescriptionDto` — AI strategy creation was returning HTTP 400 (closes #85, regression of #40)
+- **BREAKING** `WebhookEvent`: change values from dot.notation (`order.filled`) to SCREAMING_SNAKE_CASE (`ORDER_FILLED`) to match platform `CreateWebhookDto` validation — webhook creation was returning HTTP 400 (closes #86, regression of #42)
+- **BREAKING** `startStrategy()`: send lowercase `mode` (`"live"`, `"paper"`) instead of uppercase — strategy start was returning HTTP 400 (closes #87, regression of #41)
+
 ## [1.6.7] — 2026-04-12
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
@@ -94,6 +94,61 @@ describe('PolyforgeClient', () => {
       expect(() => new PolyforgeClient({ apiKey: 'k', apiUrl: 'https://api.example.com' }))
         .not.toThrow();
     });
+  });
+});
+
+describe('Platform contract compliance', () => {
+  let client: PolyforgeClient;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('aiQuery sends { query } not { question } (#84)', async () => {
+    await client.aiQuery('what is BTC?');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ query: 'what is BTC?' });
+    expect(body).not.toHaveProperty('question');
+  });
+
+  it('createStrategyFromDescription sends { description } not { query } (#85)', async () => {
+    await client.createStrategyFromDescription({ description: 'buy low sell high' });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ description: 'buy low sell high' });
+    expect(body).not.toHaveProperty('query');
+  });
+
+  it('startStrategy sends lowercase mode (#87)', async () => {
+    await client.startStrategy('strat-id', 'live');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'live' });
+  });
+
+  it('startStrategy does not uppercase paper mode (#87)', async () => {
+    await client.startStrategy('strat-id', 'paper');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'paper' });
+  });
+
+  it('WebhookEvent values use SCREAMING_SNAKE_CASE (#86)', async () => {
+    // Type-level test: these should compile without error
+    const events: import('../types').WebhookEvent[] = [
+      'ORDER_FILLED', 'STRATEGY_ERROR', 'WHALE_TRADE', 'NEWS_SIGNAL',
+      'BACKTEST_COMPLETE', 'DAILY_LOSS_LIMIT', 'MARKET_RESOLVED', 'PRICE_ALERT',
+    ];
+    expect(events).toHaveLength(8);
+    // Ensure no dot.notation values exist in the type
+    for (const e of events) {
+      expect(e).not.toContain('.');
+    }
   });
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -386,7 +386,7 @@ export class PolyforgeClient {
     marketId?: string;
   }): Promise<Strategy> {
     return this.request('POST', '/api/v1/strategies/from-description', {
-      body: { query: params.description, ...(params.marketId !== undefined && { marketId: params.marketId }) },
+      body: { description: params.description, ...(params.marketId !== undefined && { marketId: params.marketId }) },
     });
   }
 
@@ -395,7 +395,7 @@ export class PolyforgeClient {
    */
   async startStrategy(id: string, mode: 'live' | 'paper' = 'paper'): Promise<Strategy> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/start`, {
-      body: { mode: mode.toUpperCase() },
+      body: { mode },
     });
   }
 
@@ -591,7 +591,7 @@ export class PolyforgeClient {
    * Ask the Polyforge AI assistant a natural-language question.
    */
   async aiQuery(query: string): Promise<AiQueryResponse> {
-    return this.request('POST', '/api/v1/ai/query', { body: { question: query } });
+    return this.request('POST', '/api/v1/ai/query', { body: { query } });
   }
 
   // ── Direct Trading ────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,14 +3,14 @@
 export type StrategyStatus = 'IDLE' | 'RUNNING' | 'PAUSED' | 'PAPER';
 
 export type WebhookEvent =
-  | 'order.filled'
-  | 'strategy.error'
-  | 'whale.trade'
-  | 'news.signal'
-  | 'backtest.complete'
-  | 'daily.loss.limit'
-  | 'market.resolved'
-  | 'price.alert';
+  | 'ORDER_FILLED'
+  | 'STRATEGY_ERROR'
+  | 'WHALE_TRADE'
+  | 'NEWS_SIGNAL'
+  | 'BACKTEST_COMPLETE'
+  | 'DAILY_LOSS_LIMIT'
+  | 'MARKET_RESOLVED'
+  | 'PRICE_ALERT';
 
 export type OrderSide = 'BUY' | 'SELL';
 export type OrderType = 'MARKET' | 'LIMIT' | 'STOP' | 'STOP_LIMIT';


### PR DESCRIPTION
## Problem

Four breaking compat regressions from previous fixes caused every call to `aiQuery()`, `createStrategyFromDescription()`, `createWebhook()`, and `startStrategy()` to return HTTP 400 — the SDK was sending field names and enum values that don't match the platform's DTOs.

## What changed

| Method | Before (broken) | After (correct) | Issue |
|--------|-----------------|------------------|-------|
| `aiQuery()` | `{ question: ... }` | `{ query: ... }` | closes #84 |
| `createStrategyFromDescription()` | `{ query: ... }` | `{ description: ... }` | closes #85 |
| `WebhookEvent` values | `order.filled` (dot.notation) | `ORDER_FILLED` (SCREAMING_SNAKE) | closes #86 |
| `startStrategy()` mode | `"LIVE"` / `"PAPER"` | `"live"` / `"paper"` | closes #87 |

## Tests added

5 new regression tests in `client.test.ts`:
- `aiQuery sends { query } not { question }`
- `createStrategyFromDescription sends { description } not { query }`
- `startStrategy sends lowercase mode` (2 tests: live + paper)
- `WebhookEvent values use SCREAMING_SNAKE_CASE`

All 75 tests pass. Typecheck and build clean.

closes #84, closes #85, closes #86, closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)