### PR TITLE
fix(compat): rename intervalSeconds back to intervalMinutes (closes #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.9] — 2026-04-13
+
+### Fixed
+- **BREAKING** `PlaceSmartOrderParams`: rename `intervalSeconds` back to `intervalMinutes` to match platform `PlaceSmartOrderDto` — TWAP/DCA orders had `intervalSeconds` silently stripped, falling back to default interval (closes #88, regression of #62)
+
 ## [1.6.8] — 2026-04-13
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -138,6 +138,21 @@ describe('Platform contract compliance', () => {
     expect(body).toEqual({ mode: 'paper' });
   });
 
+  it('placeSmartOrder sends intervalMinutes not intervalSeconds (#88)', async () => {
+    await client.placeSmartOrder({
+      type: 'TWAP',
+      tokenId: 'tok-1',
+      side: 'BUY',
+      outcome: 'YES',
+      totalSize: 100,
+      slices: 5,
+      intervalMinutes: 15,
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toHaveProperty('intervalMinutes', 15);
+    expect(body).not.toHaveProperty('intervalSeconds');
+  });
+
   it('WebhookEvent values use SCREAMING_SNAKE_CASE (#86)', async () => {
     // Type-level test: these should compile without error
     const events: import('../types').WebhookEvent[] = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,7 +338,7 @@ export interface PlaceSmartOrderParams {
   totalSize: number;
   // TWAP / DCA
   slices?: number;
-  intervalSeconds?: number;
+  intervalMinutes?: number;
   limitPrice?: number;
   // BRACKET
   entryPrice?: number;


### PR DESCRIPTION
## Summary
- Renamed `intervalSeconds` back to `intervalMinutes` in `PlaceSmartOrderParams` to match platform's `PlaceSmartOrderDto`
- The previous fix (#62) renamed in the wrong direction, causing TWAP/DCA interval to be silently stripped by `forbidNonWhitelisted` validation

## What changed
- `src/types.ts`: `intervalSeconds` → `intervalMinutes` in `PlaceSmartOrderParams`
- Added test verifying `placeSmartOrder()` sends `intervalMinutes` (not `intervalSeconds`)
- CHANGELOG updated

## Test plan
- [x] New test: `placeSmartOrder sends intervalMinutes not intervalSeconds (#88)`
- [x] All 76 tests pass
- [x] Lint clean, build succeeds

closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)