### PR TITLE
fix(compat): fix strategy lifecycle return types and list pagination (closes #61, closes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.0] — 2026-04-13
+
+### Fixed
+- **BREAKING** Strategy lifecycle methods (`startStrategy`, `stopStrategy`, `pauseStrategy`, `resumeStrategy`): return `StrategyStatusResponse` instead of `Strategy` — the platform returns `{"status":"RUNNING"}` not a full strategy object; callers accessing `strategy.name` etc. got `undefined` (closes #61)
+- **BREAKING** List endpoints (`listStrategies`, `getOrders`, `listBacktests`, `listConditionalOrders`, `getWhaleFeed`, `getNewsSignals`, `listAlerts`, `listCopyConfigs`, `listWebhooks`, `getStrategyTemplates`, `listSmartOrders`): return `PaginatedResponse<T>` instead of `T[]` — the platform wraps all list responses in `{"data":[...],"total":N,...}` (closes #78)
+
 ## [1.6.9] — 2026-04-13
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
+import type { StrategyStatusResponse, PaginatedResponse, Strategy } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -441,5 +442,67 @@ describe('validateWebhookUrl', () => {
     await expect(validateWebhookUrl('https://v6internal.example.com/hook')).rejects.toThrow(
       'Webhook URL resolves to a blocked address (fd00::1)',
     );
+  });
+});
+
+// --- Breaking compat fixes (#61, #78) ---
+
+describe('StrategyStatusResponse type (#61)', () => {
+  it('should accept a minimal start response', () => {
+    const resp: StrategyStatusResponse = {
+      status: 'RUNNING',
+      startedAt: '2026-04-13T10:00:00Z',
+    };
+    expect(resp.status).toBe('RUNNING');
+    expect(resp.startedAt).toBe('2026-04-13T10:00:00Z');
+    expect(resp.stoppedAt).toBeUndefined();
+  });
+
+  it('should accept a stop response', () => {
+    const resp: StrategyStatusResponse = {
+      status: 'IDLE',
+      stoppedAt: '2026-04-13T10:05:00Z',
+    };
+    expect(resp.status).toBe('IDLE');
+    expect(resp.stoppedAt).toBeDefined();
+  });
+
+  it('should accept a pause response with only status', () => {
+    const resp: StrategyStatusResponse = { status: 'PAUSED' };
+    expect(resp.status).toBe('PAUSED');
+    expect(resp.startedAt).toBeUndefined();
+    expect(resp.stoppedAt).toBeUndefined();
+  });
+});
+
+describe('PaginatedResponse type (#78)', () => {
+  it('should correctly type a paginated strategy response', () => {
+    const resp: PaginatedResponse<Strategy> = {
+      data: [
+        { id: 's1', name: 'Alpha', status: 'IDLE', blocks: [], pnl: 0, tradeCount: 0, winRate: 0, createdAt: '', updatedAt: '' },
+      ],
+      total: 1,
+      page: 1,
+      limit: 10,
+      totalPages: 1,
+      hasNext: false,
+    };
+    expect(resp.data).toHaveLength(1);
+    expect(resp.data[0].id).toBe('s1');
+    expect(resp.total).toBe(1);
+    expect(resp.hasNext).toBe(false);
+  });
+
+  it('should have correct shape for empty response', () => {
+    const resp: PaginatedResponse<Strategy> = {
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 10,
+      totalPages: 0,
+      hasNext: false,
+    };
+    expect(resp.data).toHaveLength(0);
+    expect(resp.total).toBe(0);
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,6 +35,7 @@ import type {
   StrategyEvent,
   StrategyExport,
   StrategyStatus,
+  StrategyStatusResponse,
   StrategyTemplate,
   TraderScore,
   UpdateStrategyParams,
@@ -360,7 +361,7 @@ export class PolyforgeClient {
   /**
    * List strategies owned by the authenticated user.
    */
-  async listStrategies(params?: { status?: StrategyStatus }): Promise<Strategy[]> {
+  async listStrategies(params?: { status?: StrategyStatus }): Promise<PaginatedResponse<Strategy>> {
     return this.request('GET', '/api/v1/strategies', { query: params as Record<string, unknown> });
   }
 
@@ -393,7 +394,7 @@ export class PolyforgeClient {
   /**
    * Start a strategy in live or paper mode.
    */
-  async startStrategy(id: string, mode: 'live' | 'paper' = 'paper'): Promise<Strategy> {
+  async startStrategy(id: string, mode: 'live' | 'paper' = 'paper'): Promise<StrategyStatusResponse> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/start`, {
       body: { mode },
     });
@@ -402,14 +403,14 @@ export class PolyforgeClient {
   /**
    * Stop a running strategy.
    */
-  async stopStrategy(id: string): Promise<Strategy> {
+  async stopStrategy(id: string): Promise<StrategyStatusResponse> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/stop`);
   }
 
   /**
    * List available strategy templates.
    */
-  async getStrategyTemplates(): Promise<StrategyTemplate[]> {
+  async getStrategyTemplates(): Promise<PaginatedResponse<StrategyTemplate>> {
     return this.request('GET', '/api/v1/strategies/templates');
   }
 
@@ -444,14 +445,14 @@ export class PolyforgeClient {
   /**
    * Pause a running strategy.
    */
-  async pauseStrategy(id: string): Promise<Strategy> {
+  async pauseStrategy(id: string): Promise<StrategyStatusResponse> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/pause`);
   }
 
   /**
    * Resume a paused strategy.
    */
-  async resumeStrategy(id: string): Promise<Strategy> {
+  async resumeStrategy(id: string): Promise<StrategyStatusResponse> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/resume`);
   }
 
@@ -485,7 +486,7 @@ export class PolyforgeClient {
     strategyId?: string;
     from?: string;
     to?: string;
-  }): Promise<Order[]> {
+  }): Promise<PaginatedResponse<Order>> {
     return this.request('GET', '/api/v1/orders', { query: params as Record<string, unknown> });
   }
 
@@ -502,7 +503,7 @@ export class PolyforgeClient {
   // -- Backtests --
 
   /** List backtests. */
-  async listBacktests(): Promise<Backtest[]> {
+  async listBacktests(): Promise<PaginatedResponse<Backtest>> {
     return this.request('GET', '/api/v1/backtests');
   }
 
@@ -519,7 +520,7 @@ export class PolyforgeClient {
   // -- Conditional Orders --
 
   /** List conditional orders. */
-  async listConditionalOrders(): Promise<ConditionalOrder[]> {
+  async listConditionalOrders(): Promise<PaginatedResponse<ConditionalOrder>> {
     return this.request('GET', '/api/v1/orders/conditional');
   }
 
@@ -531,14 +532,14 @@ export class PolyforgeClient {
   /**
    * Get the whale-trade feed.
    */
-  async getWhaleFeed(params?: { minSize?: number }): Promise<WhaleTrade[]> {
+  async getWhaleFeed(params?: { minSize?: number }): Promise<PaginatedResponse<WhaleTrade>> {
     return this.request('GET', '/api/v1/whales/feed', { query: params as Record<string, unknown> });
   }
 
   /**
    * Get AI-generated news signals.
    */
-  async getNewsSignals(params?: { minConfidence?: number }): Promise<NewsSignal[]> {
+  async getNewsSignals(params?: { minConfidence?: number }): Promise<PaginatedResponse<NewsSignal>> {
     return this.request('GET', '/api/v1/news/signals', { query: params as Record<string, unknown> });
   }
 
@@ -547,7 +548,7 @@ export class PolyforgeClient {
   /**
    * List configured alerts.
    */
-  async listAlerts(): Promise<Alert[]> {
+  async listAlerts(): Promise<PaginatedResponse<Alert>> {
     return this.request('GET', '/api/v1/alerts');
   }
 
@@ -564,14 +565,14 @@ export class PolyforgeClient {
   /**
    * List copy-trading configurations.
    */
-  async listCopyConfigs(): Promise<CopyConfig[]> {
+  async listCopyConfigs(): Promise<PaginatedResponse<CopyConfig>> {
     return this.request('GET', '/api/v1/copy');
   }
 
   /**
    * List registered webhooks.
    */
-  async listWebhooks(): Promise<Webhook[]> {
+  async listWebhooks(): Promise<PaginatedResponse<Webhook>> {
     return this.request('GET', '/api/v1/webhooks');
   }
 
@@ -664,7 +665,7 @@ export class PolyforgeClient {
   /**
    * List your smart orders with child order progress.
    */
-  async listSmartOrders(): Promise<SmartOrder[]> {
+  async listSmartOrders(): Promise<PaginatedResponse<SmartOrder>> {
     return this.request('GET', '/api/v1/orders/smart');
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export type {
   StrategyEventType,
   StrategyExport,
   StrategyStatus,
+  StrategyStatusResponse,
   StrategyTemplate,
   Token,
   TraderScore,

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,13 @@ export interface Strategy {
   updatedAt: string;
 }
 
+/** Response from strategy lifecycle operations (start/stop/pause/resume). */
+export interface StrategyStatusResponse {
+  status: StrategyStatus;
+  startedAt?: string;
+  stoppedAt?: string;
+}
+
 export interface StrategyTemplate {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

- **#61**: Strategy lifecycle methods (`startStrategy`, `stopStrategy`, `pauseStrategy`, `resumeStrategy`) now return `StrategyStatusResponse` instead of `Strategy` — platform returns `{"status":"RUNNING"}` not a full object
- **#78**: 11 list endpoints now return `PaginatedResponse<T>` instead of `T[]` — platform wraps all list responses in `{"data":[...],"total":N,...}`

## Test plan

- [x] 5 new regression tests added (81 total, all pass)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] `StrategyStatusResponse` correctly typed and exported
- [x] `PaginatedResponse<T>` already existed in types — just needed to update method signatures

closes #61, closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)