### PR TITLE
fix(errors): add suggestion field to PolyforgeError (closes #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.1] — 2026-04-13
+
+### Fixed
+- `PolyforgeError`: add optional `suggestion` field to capture platform error response hints that help users fix common issues; the field is extracted from the JSON error body `suggestion` property (closes #89)
+
 ## [1.7.0] — 2026-04-13
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -220,6 +220,58 @@ describe('PolyforgeError', () => {
     });
   });
 
+  describe('suggestion field (#89)', () => {
+    it('should capture suggestion from constructor params', () => {
+      const error = new PolyforgeError({
+        status: 400,
+        code: 'INVALID_STRATEGY',
+        message: 'Strategy has no blocks',
+        suggestion: 'Add at least one condition block before starting the strategy.',
+      });
+
+      expect(error.suggestion).toBe('Add at least one condition block before starting the strategy.');
+    });
+
+    it('should be undefined when not provided', () => {
+      const error = new PolyforgeError({
+        status: 400,
+        code: 'BAD_REQUEST',
+        message: 'Bad request',
+      });
+
+      expect(error.suggestion).toBeUndefined();
+    });
+
+    it('should be extracted from API error response body', async () => {
+      const client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'STRATEGY_LIMIT_REACHED',
+            message: 'You have reached the maximum number of strategies',
+            suggestion: 'Upgrade to Pro for up to 10 strategies.',
+            requestId: 'req-456',
+          }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+      try {
+        await client.listMarkets();
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(PolyforgeError);
+        const pErr = err as PolyforgeError;
+        expect(pErr.status).toBe(403);
+        expect(pErr.code).toBe('STRATEGY_LIMIT_REACHED');
+        expect(pErr.suggestion).toBe('Upgrade to Pro for up to 10 strategies.');
+        expect(pErr.requestId).toBe('req-456');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
   describe('error types', () => {
     it('should handle 401 Unauthorized', () => {
       const error = new PolyforgeError({

--- a/src/client.ts
+++ b/src/client.ts
@@ -312,7 +312,7 @@ export class PolyforgeClient {
     });
 
     if (!response.ok) {
-      let errorBody: { code?: string; message?: string; requestId?: string } = {};
+      let errorBody: { code?: string; message?: string; requestId?: string; suggestion?: string } = {};
       try {
         errorBody = (await response.json()) as typeof errorBody;
       } catch {
@@ -324,6 +324,7 @@ export class PolyforgeClient {
         code: errorBody.code ?? 'UNKNOWN_ERROR',
         message: errorBody.message ?? `Request failed with status ${response.status}`,
         requestId: errorBody.requestId ?? response.headers.get('x-request-id') ?? undefined,
+        suggestion: errorBody.suggestion,
       });
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,17 +11,22 @@ export class PolyforgeError extends Error {
   /** Unique identifier for the failed request, useful for support inquiries. */
   public readonly requestId: string | undefined;
 
+  /** Optional suggestion from the platform to help the user fix the error. */
+  public readonly suggestion: string | undefined;
+
   constructor(params: {
     status: number;
     code: string;
     message: string;
     requestId?: string;
+    suggestion?: string;
   }) {
     super(params.message);
     this.name = 'PolyforgeError';
     this.status = params.status;
     this.code = params.code;
     this.requestId = params.requestId;
+    this.suggestion = params.suggestion;
 
     // Maintain proper stack trace in V8 environments
     if (Error.captureStackTrace) {


### PR DESCRIPTION
## Summary
- Add optional `suggestion` field to `PolyforgeError` class to capture platform error response hints
- Extract `suggestion` from the JSON error body in the `request()` helper method
- Add 3 tests: constructor with suggestion, undefined when omitted, end-to-end extraction from mocked API response

## What changed
- `src/errors.ts`: new `suggestion?: string` property + constructor param
- `src/client.ts`: parse `suggestion` from error response body and pass to `PolyforgeError`
- `src/__tests__/client.test.ts`: 3 new test cases under `suggestion field (#89)` describe block
- `CHANGELOG.md`: added v1.7.1 entry

## Test plan
- [x] `pnpm lint` passes (tsc --noEmit)
- [x] `pnpm test` passes (84 tests, including 3 new)
- [x] `pnpm build` passes

closes #89