### PR TITLE
fix(compat): add missing query parameters to 5 list methods (closes #72, #73, #74, #75, #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.12.0] — 2026-04-13
+
+### Added
+- `listMarkets()`: add `sort` and `closed` query parameters matching platform `MarketQueryDto` (closes #74)
+- `listStrategies()`: add `sort`, `page`, and `limit` query parameters matching platform `StrategyQueryDto` (closes #79)
+- `getOrders()`: add `marketId` and `page` query parameters matching platform `OrderQueryDto` (closes #75)
+- `listBacktests()`: add `strategyId`, `status`, `page`, `limit` query parameters matching platform `BacktestQueryDto` (closes #72)
+- `listConditionalOrders()`: add `status`, `type`, `page`, `limit` query parameters matching platform `ConditionalOrderQueryDto` (closes #73)
+
 ## [1.11.0] — 2026-04-13
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1286,3 +1286,72 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
     expect((pos as any).marketName).toBeUndefined();
   });
 });
+
+// --- Missing query parameters (#72, #73, #74, #75, #79) ---
+
+describe('Missing query parameters on list methods', () => {
+  let client: PolyforgeClient;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ data: [], total: 0, page: 1, limit: 10, totalPages: 0, hasNext: false }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('listMarkets sends sort and closed params (#74)', async () => {
+    await client.listMarkets({ sort: 'volume', closed: true, limit: 5 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('sort')).toBe('volume');
+    expect(url.searchParams.get('closed')).toBe('true');
+    expect(url.searchParams.get('limit')).toBe('5');
+  });
+
+  it('listStrategies sends sort, page, and limit params (#79)', async () => {
+    await client.listStrategies({ status: 'RUNNING', sort: 'pnl', page: 2, limit: 20 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('status')).toBe('RUNNING');
+    expect(url.searchParams.get('sort')).toBe('pnl');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('limit')).toBe('20');
+  });
+
+  it('getOrders sends marketId and page params (#75)', async () => {
+    await client.getOrders({ marketId: 'mkt-1', page: 3, limit: 50 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('marketId')).toBe('mkt-1');
+    expect(url.searchParams.get('page')).toBe('3');
+  });
+
+  it('listBacktests sends strategyId, status, page, limit params (#72)', async () => {
+    await client.listBacktests({ strategyId: 's-1', status: 'COMPLETED', page: 1, limit: 10 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('strategyId')).toBe('s-1');
+    expect(url.searchParams.get('status')).toBe('COMPLETED');
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.get('limit')).toBe('10');
+  });
+
+  it('listConditionalOrders sends status, type, page, limit params (#73)', async () => {
+    await client.listConditionalOrders({ status: 'PENDING', type: 'STOP_LOSS', page: 1, limit: 25 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('status')).toBe('PENDING');
+    expect(url.searchParams.get('type')).toBe('STOP_LOSS');
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.get('limit')).toBe('25');
+  });
+
+  it('all list methods still work with no params', async () => {
+    await client.listMarkets();
+    await client.listStrategies();
+    await client.getOrders();
+    await client.listBacktests();
+    await client.listConditionalOrders();
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -45,6 +45,8 @@ import type {
   WhaleTrade,
   Backtest,
   ConditionalOrder,
+  ConditionalOrderStatus,
+  ConditionalOrderType,
   CreateAlertParams,
   CreateConditionalOrderParams,
   PortfolioPnl,
@@ -345,6 +347,8 @@ export class PolyforgeClient {
   async listMarkets(params?: {
     search?: string;
     category?: string;
+    sort?: 'volume' | 'endDate' | 'firstSeenAt' | 'newest' | 'closing_soon' | 'liquidity';
+    closed?: boolean;
     limit?: number;
     page?: number;
   }): Promise<PaginatedResponse<Market>> {
@@ -363,7 +367,12 @@ export class PolyforgeClient {
   /**
    * List strategies owned by the authenticated user.
    */
-  async listStrategies(params?: { status?: StrategyStatus }): Promise<PaginatedResponse<Strategy>> {
+  async listStrategies(params?: {
+    status?: StrategyStatus;
+    sort?: 'newest' | 'oldest' | 'name' | 'pnl';
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<Strategy>> {
     return this.request('GET', '/api/v1/strategies', { query: params as Record<string, unknown> });
   }
 
@@ -484,8 +493,10 @@ export class PolyforgeClient {
    */
   async getOrders(params?: {
     limit?: number;
+    page?: number;
     status?: string;
     strategyId?: string;
+    marketId?: string;
     from?: string;
     to?: string;
   }): Promise<PaginatedResponse<Order>> {
@@ -504,9 +515,14 @@ export class PolyforgeClient {
 
   // -- Backtests --
 
-  /** List backtests. */
-  async listBacktests(): Promise<PaginatedResponse<Backtest>> {
-    return this.request('GET', '/api/v1/backtests');
+  /** List backtests with optional filtering and pagination. */
+  async listBacktests(params?: {
+    strategyId?: string;
+    status?: 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<Backtest>> {
+    return this.request('GET', '/api/v1/backtests', { query: params as Record<string, unknown> });
   }
 
   /** Get a single backtest by ID. */
@@ -521,9 +537,14 @@ export class PolyforgeClient {
 
   // -- Conditional Orders --
 
-  /** List conditional orders. */
-  async listConditionalOrders(): Promise<PaginatedResponse<ConditionalOrder>> {
-    return this.request('GET', '/api/v1/orders/conditional');
+  /** List conditional orders with optional filtering and pagination. */
+  async listConditionalOrders(params?: {
+    status?: ConditionalOrderStatus;
+    type?: ConditionalOrderType;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<ConditionalOrder>> {
+    return this.request('GET', '/api/v1/orders/conditional', { query: params as Record<string, unknown> });
   }
 
   /** Create a conditional order. */


### PR DESCRIPTION
## Summary

- Add missing `sort` and `closed` params to `listMarkets()` matching `MarketQueryDto`
- Add missing `sort`, `page`, `limit` params to `listStrategies()` matching `StrategyQueryDto`
- Add missing `marketId` and `page` params to `getOrders()` matching `OrderQueryDto`
- Add missing `strategyId`, `status`, `page`, `limit` params to `listBacktests()` matching `BacktestQueryDto`
- Add missing `status`, `type`, `page`, `limit` params to `listConditionalOrders()` matching `ConditionalOrderQueryDto`

## Tests

- 132 tests passing (6 new)
- tsc clean, build clean

closes #72, closes #73, closes #74, closes #75, closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)