### PR TITLE
fix(compat): add conditional order endpoints + PnL query params (closes #19, #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.13.0] — 2026-04-13
+
+### Added
+- `getConditionalOrder(id)`: GET a single conditional order by ID (closes #65)
+- `cancelConditionalOrder(id)`: DELETE/cancel a conditional order by ID (closes #65)
+- `getPortfolioPnl()`: add optional `period` (`'7d' | '30d' | '90d' | 'allTime'`) and `strategyId` query parameters (closes #19)
+- `PortfolioPnlParams` type for PnL query filtering
+
 ## [1.12.0] — 2026-04-13
 
 ### Added

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
-import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode } from '../types';
+import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -1353,5 +1353,57 @@ describe('Missing query parameters on list methods', () => {
     await client.listBacktests();
     await client.listConditionalOrders();
     expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it('getPortfolioPnl sends period and strategyId query params (#19)', async () => {
+    await client.getPortfolioPnl({ period: '30d', strategyId: 's-42' });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('period')).toBe('30d');
+    expect(url.searchParams.get('strategyId')).toBe('s-42');
+  });
+
+  it('getPortfolioPnl works with no params (#19)', async () => {
+    await client.getPortfolioPnl();
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.toString()).toBe('');
+  });
+});
+
+// --- Conditional order get/cancel (#65) ---
+
+describe('getConditionalOrder and cancelConditionalOrder (#65)', () => {
+  let client: PolyforgeClient;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ id: 'co-1', status: 'PENDING' }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('getConditionalOrder sends GET to /api/v1/orders/conditional/:id', async () => {
+    await client.getConditionalOrder('co-1');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/orders/conditional/co-1');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+  });
+
+  it('cancelConditionalOrder sends DELETE to /api/v1/orders/conditional/:id', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await client.cancelConditionalOrder('co-2');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/orders/conditional/co-2');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('DELETE');
+  });
+
+  it('getConditionalOrder encodes special characters in ID', async () => {
+    await client.getConditionalOrder('co/special&id');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toContain('co%2Fspecial%26id');
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,6 +50,7 @@ import type {
   CreateAlertParams,
   CreateConditionalOrderParams,
   PortfolioPnl,
+  PortfolioPnlParams,
   RunBacktestParams,
 } from './types.js';
 import { KNOWN_STRATEGY_EVENTS } from './types.js';
@@ -484,8 +485,8 @@ export class PolyforgeClient {
   }
 
   /** Get portfolio profit-and-loss breakdown with history. */
-  async getPortfolioPnl(): Promise<PortfolioPnl> {
-    return this.request('GET', '/api/v1/portfolio/pnl');
+  async getPortfolioPnl(params?: PortfolioPnlParams): Promise<PortfolioPnl> {
+    return this.request('GET', '/api/v1/portfolio/pnl', { query: params as Record<string, unknown> });
   }
 
   /**
@@ -550,6 +551,16 @@ export class PolyforgeClient {
   /** Create a conditional order. */
   async createConditionalOrder(params: CreateConditionalOrderParams): Promise<ConditionalOrder> {
     return this.request('POST', '/api/v1/orders/conditional', { body: params });
+  }
+
+  /** Get a single conditional order by ID. */
+  async getConditionalOrder(id: string): Promise<ConditionalOrder> {
+    return this.request('GET', `/api/v1/orders/conditional/${encodeURIComponent(id)}`);
+  }
+
+  /** Cancel a conditional order by ID. */
+  async cancelConditionalOrder(id: string): Promise<void> {
+    return this.request('DELETE', `/api/v1/orders/conditional/${encodeURIComponent(id)}`);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
   Portfolio,
   PolyforgeClientOptions,
   PortfolioPnl,
+  PortfolioPnlParams,
   Position,
   RedeemPositionParams,
   RunBacktestParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -626,6 +626,11 @@ export interface CreateConditionalOrderParams {
 
 // ── Portfolio PnL ──────────────────────────────────────────────────────────
 
+export interface PortfolioPnlParams {
+  period?: '7d' | '30d' | '90d' | 'allTime';
+  strategyId?: string;
+}
+
 export interface PortfolioPnl {
   totalPnl: number;
   realizedPnl: number;


### PR DESCRIPTION
## Summary
- **#19**: Add `period` and `strategyId` optional query params to `getPortfolioPnl()` with new `PortfolioPnlParams` type
- **#65**: Add `getConditionalOrder(id)` (GET) and `cancelConditionalOrder(id)` (DELETE) methods following existing conditional order patterns

## Test plan
- [x] All 137 existing tests pass
- [x] New tests cover `getConditionalOrder`, `cancelConditionalOrder`, and `getPortfolioPnl` with/without params
- [x] Lint clean, build succeeds

closes #19, closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)