### PR TITLE
feat(client): add API key management — list, create, revoke (closes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.17.0] — 2026-04-14
+
+### Added
+- **API key management** — `listApiKeys()`, `createApiKey()`, `revokeApiKey()` methods covering GET/POST/DELETE `/api/v1/api-keys`. New exported types: `ApiKey`, `ApiKeyScope`, `CreateApiKeyParams`, `CreateApiKeyResponse`. The `token` field is only available in the `createApiKey` response (shown once, never retrievable again). (closes #53)
+
 ## [1.16.0] — 2026-04-14
 
 ### Breaking Changes

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1631,4 +1631,78 @@ describe('Price history & order book (issue #52)', () => {
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toContain('token%2Fspecial%26id');
   });
+
+  // ── API Keys (#53) ──────────────────────────────────────────────────────
+
+  it('listApiKeys calls GET /api/v1/api-keys', async () => {
+    const mockKeys = [{ id: 'k-1', name: 'My Key', prefix: 'pf_abc123', scopes: ['READ'], expiresAt: null, lastUsedAt: null, createdAt: '2026-04-14T00:00:00Z' }];
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockKeys), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const result = await client.listApiKeys();
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/api-keys');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+    expect(result).toEqual(mockKeys);
+  });
+
+  it('createApiKey sends name and scopes to POST /api/v1/api-keys', async () => {
+    const mockResponse = { id: 'k-1', name: 'Trading', prefix: 'pf_abc123', scopes: ['READ', 'TRADE'], createdAt: '2026-04-14T00:00:00Z', token: 'pf_abc123...' };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const result = await client.createApiKey({ name: 'Trading', scopes: ['READ', 'TRADE'] });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/api-keys');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ name: 'Trading', scopes: ['READ', 'TRADE'] });
+    expect(result.token).toBe('pf_abc123...');
+  });
+
+  it('createApiKey sends only name when scopes omitted', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'k-1', name: 'Default', prefix: 'pf_x', scopes: ['READ'], createdAt: '2026-04-14T00:00:00Z', token: 'pf_x...' }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await client.createApiKey({ name: 'Default' });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ name: 'Default' });
+    expect(body).not.toHaveProperty('scopes');
+  });
+
+  it('revokeApiKey calls DELETE /api/v1/api-keys/:id', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    await client.revokeApiKey('key-uuid-1');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/api-keys/key-uuid-1');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('DELETE');
+  });
+
+  it('revokeApiKey encodes special characters in id', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+    await client.revokeApiKey('key/special&id');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toContain('key%2Fspecial%26id');
+  });
+
+  it('ApiKey type has correct platform fields', () => {
+    const key: import('../types').ApiKey = {
+      id: 'k-1',
+      name: 'My Key',
+      prefix: 'pf_abc123',
+      scopes: ['READ'],
+      expiresAt: null,
+      lastUsedAt: '2026-04-14T00:00:00Z',
+      createdAt: '2026-04-14T00:00:00Z',
+    };
+    expect(key.prefix).toBe('pf_abc123');
+    expect(key.scopes).toEqual(['READ']);
+    expect(key.expiresAt).toBeNull();
+    expect((key as any).token).toBeUndefined();
+    expect((key as any).tokenHash).toBeUndefined();
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,11 +5,14 @@ import type {
   AccuracyScore,
   AiQueryResponse,
   Alert,
+  ApiKey,
   ArbitrageOpportunity,
   BrowseMarketplaceParams,
   CancelOrderResponse,
   ClosePositionParams,
   CopyConfig,
+  CreateApiKeyParams,
+  CreateApiKeyResponse,
   CreateStrategyParams,
   ImportStrategyParams,
   LpPosition,
@@ -598,6 +601,31 @@ export class PolyforgeClient {
    */
   async getNewsSignals(params?: { minConfidence?: number }): Promise<PaginatedResponse<NewsSignal>> {
     return this.request('GET', '/api/v1/news/signals', { query: params as Record<string, unknown> });
+  }
+
+  // ── API Keys ────────────────────────────────────────────────────────────
+
+  /**
+   * List all API keys for the authenticated user.
+   * The raw token is never returned — only the prefix is available for identification.
+   */
+  async listApiKeys(): Promise<ApiKey[]> {
+    return this.request('GET', '/api/v1/api-keys');
+  }
+
+  /**
+   * Create a new API key. The raw `token` is returned only once in the response
+   * and cannot be retrieved later — store it securely.
+   */
+  async createApiKey(params: CreateApiKeyParams): Promise<CreateApiKeyResponse> {
+    return this.request('POST', '/api/v1/api-keys', { body: params });
+  }
+
+  /**
+   * Revoke an API key by ID. The key is permanently deactivated.
+   */
+  async revokeApiKey(id: string): Promise<void> {
+    return this.request('DELETE', `/api/v1/api-keys/${encodeURIComponent(id)}`);
   }
 
   // ── Configuration ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ export { KNOWN_STRATEGY_EVENTS } from './types.js';
 export type {
   AiQueryResponse,
   Alert,
+  ApiKey,
+  ApiKeyScope,
   Backtest,
+  CreateApiKeyParams,
+  CreateApiKeyResponse,
   CancelOrderResponse,
   ClosePositionParams,
   ConditionalOrder,

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,6 +210,29 @@ export interface NewsSignal {
   };
 }
 
+// ── API Keys ───────────────────────────────────────────────────────────────
+
+export type ApiKeyScope = 'READ' | 'TRADE' | 'STRATEGY' | 'WEBHOOK';
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: ApiKeyScope[];
+  expiresAt: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateApiKeyParams {
+  name: string;
+  scopes?: ApiKeyScope[];
+}
+
+export interface CreateApiKeyResponse extends Pick<ApiKey, 'id' | 'name' | 'prefix' | 'scopes' | 'createdAt'> {
+  token: string;
+}
+
 // ── Configuration ───────────────────────────────────────────────────────────
 
 export interface Alert {


### PR DESCRIPTION
## Summary
- Add `listApiKeys()`, `createApiKey()`, `revokeApiKey()` to `PolyforgeClient`
- New exported types: `ApiKey`, `ApiKeyScope`, `CreateApiKeyParams`, `CreateApiKeyResponse`
- Verified against platform source: `services/api-service/src/api-keys/api-keys.controller.ts`
- The create response includes `token` (shown once only); list response includes `prefix` for identification

## Test plan
- [x] 6 new tests: listApiKeys GET, createApiKey POST with scopes, createApiKey POST without scopes, revokeApiKey DELETE, revokeApiKey URL encoding, ApiKey type contract
- [x] All 161 tests pass
- [x] Lint clean
- [x] Build succeeds

closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)