### PR TITLE
feat(client): add CSV export methods for orders and portfolio (closes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **API key management** — `listApiKeys()`, `createApiKey()`, `revokeApiKey()` methods covering GET/POST/DELETE `/api/v1/api-keys`. New exported types: `ApiKey`, `ApiKeyScope`, `CreateApiKeyParams`, `CreateApiKeyResponse`. The `token` field is only available in the `createApiKey` response (shown once, never retrievable again). (closes #53)
+- **CSV export methods** — `exportOrdersCsv()` and `exportPortfolioCsv()` for GET `/api/v1/orders/export/csv` and GET `/api/v1/portfolio/export/csv`. Returns raw CSV string. Adds internal `requestText()` helper for non-JSON responses. (closes #55)
 
 ## [1.16.0] — 2026-04-14
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1705,4 +1705,47 @@ describe('Price history & order book (issue #52)', () => {
     expect((key as any).token).toBeUndefined();
     expect((key as any).tokenHash).toBeUndefined();
   });
+
+  // ── CSV Exports (#55) ────────────────────────────────────────────────────
+
+  it('exportOrdersCsv calls GET /api/v1/orders/export/csv and returns string', async () => {
+    const csvData = 'id,marketId,side,size,price\norder-1,mkt-1,BUY,10,0.65';
+    fetchSpy.mockResolvedValueOnce(
+      new Response(csvData, { status: 200, headers: { 'Content-Type': 'text/csv' } }),
+    );
+    const result = await client.exportOrdersCsv();
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/orders/export/csv');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+    expect(result).toBe(csvData);
+  });
+
+  it('exportPortfolioCsv calls GET /api/v1/portfolio/export/csv and returns string', async () => {
+    const csvData = 'tokenId,outcome,size,avgPrice\ntok-1,YES,100,0.55';
+    fetchSpy.mockResolvedValueOnce(
+      new Response(csvData, { status: 200, headers: { 'Content-Type': 'text/csv' } }),
+    );
+    const result = await client.exportPortfolioCsv();
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/portfolio/export/csv');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+    expect(result).toBe(csvData);
+  });
+
+  it('exportOrdersCsv throws PolyforgeError on failure', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ code: 'UNAUTHORIZED', message: 'Invalid token' }), { status: 401, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await expect(client.exportOrdersCsv()).rejects.toThrow('Invalid token');
+  });
+
+  it('requestText does not send Content-Type header', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('csv-data', { status: 200, headers: { 'Content-Type': 'text/csv' } }),
+    );
+    await client.exportOrdersCsv();
+    const headers = fetchSpy.mock.calls[0][1]!.headers as Record<string, string>;
+    expect(headers).not.toHaveProperty('Content-Type');
+    expect(headers['Authorization']).toBe('Bearer test-key');
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -350,6 +350,53 @@ export class PolyforgeClient {
     return (await response.json()) as T;
   }
 
+  /**
+   * Internal helper for endpoints that return non-JSON (e.g. CSV) responses.
+   * Returns the raw response body as a string.
+   */
+  private async requestText(
+    method: string,
+    path: string,
+    options?: { query?: Record<string, unknown> },
+  ): Promise<string> {
+    const url = new URL(`${this.baseUrl}${path}`);
+
+    if (options?.query) {
+      for (const [key, value] of Object.entries(options.query)) {
+        if (value !== undefined && value !== null) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    const response = await fetch(url.toString(), {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      signal: AbortSignal.timeout(this.timeout),
+    });
+
+    if (!response.ok) {
+      let errorBody: { code?: string; message?: string; requestId?: string; suggestion?: string } = {};
+      try {
+        errorBody = (await response.json()) as typeof errorBody;
+      } catch {
+        // Body may not be JSON
+      }
+
+      throw new PolyforgeError({
+        status: response.status,
+        code: errorBody.code ?? 'UNKNOWN_ERROR',
+        message: errorBody.message ?? `Request failed with status ${response.status}`,
+        requestId: errorBody.requestId ?? response.headers.get('x-request-id') ?? undefined,
+        suggestion: errorBody.suggestion,
+      });
+    }
+
+    return response.text();
+  }
+
   // ── Markets ─────────────────────────────────────────────────────────────
 
   /**
@@ -535,6 +582,22 @@ export class PolyforgeClient {
    */
   async getScore(): Promise<TraderScore> {
     return this.request('GET', '/api/v1/scores/me');
+  }
+
+  // ── CSV Exports ─────────────────────────────────────────────────────────
+
+  /**
+   * Export all orders as a CSV file. Returns the raw CSV string.
+   */
+  async exportOrdersCsv(): Promise<string> {
+    return this.requestText('GET', '/api/v1/orders/export/csv');
+  }
+
+  /**
+   * Export portfolio positions as a CSV file. Returns the raw CSV string.
+   */
+  async exportPortfolioCsv(): Promise<string> {
+    return this.requestText('GET', '/api/v1/portfolio/export/csv');
   }
 
   // ── Social & Signals ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `exportOrdersCsv()` and `exportPortfolioCsv()` to `PolyforgeClient`
- New internal `requestText()` helper for non-JSON responses (text/csv)
- Verified against platform source: `orders.controller.ts` exportCsv and `portfolio.controller.ts` exportCsv

## Test plan
- [x] 4 new tests: exportOrdersCsv GET, exportPortfolioCsv GET, error handling, no Content-Type header
- [x] All 159 tests pass
- [x] Lint clean
- [x] Build succeeds

closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)