### PR TITLE
feat(client): add runQuickBacktest and getBacktestOrders methods (closes #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.19.0] — 2026-04-14
+
+### Added
+- **Quick backtest** — `runQuickBacktest(params)` covering POST `/api/v1/backtests/quick` for synchronous backtest execution. (closes #58)
+- **Backtest orders** — `getBacktestOrders(id)` covering GET `/api/v1/backtests/:id/orders` to retrieve orders generated during a backtest. (closes #58)
+
 ## [1.18.0] — 2026-04-14
 
 ### Added

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1350,6 +1350,24 @@ describe('Missing query parameters on list methods', () => {
     expect(url.searchParams.get('limit')).toBe('10');
   });
 
+  it('runQuickBacktest posts to /backtests/quick (#58)', async () => {
+    await client.runQuickBacktest({ strategyId: 's-1', dateRangeStart: '2026-01-01', dateRangeEnd: '2026-03-01' });
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toContain('/api/v1/backtests/quick');
+    expect(opts.method).toBe('POST');
+    const body = JSON.parse(opts.body);
+    expect(body.strategyId).toBe('s-1');
+    expect(body.dateRangeStart).toBe('2026-01-01');
+    expect(body.dateRangeEnd).toBe('2026-03-01');
+  });
+
+  it('getBacktestOrders fetches orders for a backtest (#58)', async () => {
+    await client.getBacktestOrders('bt-99');
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toContain('/api/v1/backtests/bt-99/orders');
+    expect(opts.method).toBe('GET');
+  });
+
   it('listConditionalOrders sends status, type, page, limit params (#73)', async () => {
     await client.listConditionalOrders({ status: 'PENDING', type: 'STOP_LOSS', page: 1, limit: 25 });
     const url = new URL(fetchSpy.mock.calls[0][0] as string);

--- a/src/client.ts
+++ b/src/client.ts
@@ -711,6 +711,16 @@ export class PolyforgeClient {
     return this.request('POST', '/api/v1/backtests', { body: params });
   }
 
+  /** Run a quick (synchronous) backtest that returns results immediately. */
+  async runQuickBacktest(params: RunBacktestParams): Promise<Backtest> {
+    return this.request('POST', '/api/v1/backtests/quick', { body: params });
+  }
+
+  /** Get orders generated during a backtest. */
+  async getBacktestOrders(id: string): Promise<Order[]> {
+    return this.request('GET', `/api/v1/backtests/${encodeURIComponent(id)}/orders`);
+  }
+
   // -- Conditional Orders --
 
   /** List conditional orders with optional filtering and pagination. */


### PR DESCRIPTION
## Summary
- Adds `runQuickBacktest(params)` → POST `/api/v1/backtests/quick` for synchronous backtest execution
- Adds `getBacktestOrders(id)` → GET `/api/v1/backtests/:id/orders` to retrieve orders from a backtest
- 2 new tests (178 total), typecheck + build clean

## What was missing
The SDK had `listBacktests`, `getBacktest`, and `runBacktest` but was missing the quick (synchronous) endpoint and the backtest orders endpoint.

closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)