### PR TITLE
fix(security): cap SSE buffer at 1 MB to prevent memory exhaustion (closes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.19.1] — 2026-04-14
+
+### Security
+- **SSE buffer cap** — `watchStrategy()` now enforces a `MAX_SSE_BUFFER_SIZE` (1 MB) on the internal SSE read buffer. A malicious or misconfigured server sending a single event larger than 1 MB will cause the stream to throw a `PolyforgeError` (`STREAM_ERROR`) instead of consuming unbounded memory. (closes #43)
+
 ## [1.19.0] — 2026-04-14
 
 ### Added

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1908,3 +1908,60 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(url.searchParams.has('limit')).toBe(false);
   });
 });
+
+describe('SSE buffer size cap (#43)', () => {
+  it('should throw PolyforgeError when SSE buffer exceeds 1 MB', async () => {
+    const client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+
+    // Create a payload larger than 1 MB with no newlines so the buffer keeps growing
+    const oversizedChunk = 'x'.repeat(1_048_577);
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(oversizedChunk));
+        controller.close();
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      { ok: true, status: 200, body: stream } as any,
+    );
+
+    const gen = client.watchStrategy('strat-1');
+    try {
+      await gen.next();
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PolyforgeError);
+      const pErr = err as PolyforgeError;
+      expect(pErr.code).toBe('STREAM_ERROR');
+      expect(pErr.message).toContain('maximum buffer size');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('should not throw for payloads under 1 MB', async () => {
+    const client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+
+    const event = JSON.stringify({ type: 'status', status: 'running' });
+    const ssePayload = `data: ${event}\n\n`;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(ssePayload));
+        controller.close();
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      { ok: true, status: 200, body: stream } as any,
+    );
+
+    const gen = client.watchStrategy('strat-1');
+    const result = await gen.next();
+    expect(result.value).toEqual({ type: 'status', status: 'running' });
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,6 +76,7 @@ import { KNOWN_STRATEGY_EVENTS } from './types.js';
 const DEFAULT_BASE_URL = 'https://api.polyforge.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_STREAM_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours for long-lived SSE streams
+const MAX_SSE_BUFFER_SIZE = 1_048_576; // 1 MB — prevents memory exhaustion from unbounded SSE payloads
 
 /**
  * Expand a compressed IPv6 address into its full 8-group colon-hex form.
@@ -1101,6 +1102,13 @@ export class PolyforgeClient {
         if (done) break;
 
         buf += decoder.decode(value, { stream: true });
+        if (buf.length > MAX_SSE_BUFFER_SIZE) {
+          throw new PolyforgeError({
+            status: 0,
+            code: 'STREAM_ERROR',
+            message: `SSE event exceeded maximum buffer size (${MAX_SSE_BUFFER_SIZE} bytes)`,
+          });
+        }
         const lines = buf.split('\n');
         buf = lines.pop() ?? '';
 


### PR DESCRIPTION
## Summary

- `watchStrategy()` SSE read loop had no upper bound on buffer size — a malicious or misconfigured server sending a single event without newlines could grow the buffer until the process ran out of memory.
- Added `MAX_SSE_BUFFER_SIZE` constant (1 MB / 1,048,576 bytes) and a guard after each `buf += decoder.decode(...)` that throws a `PolyforgeError` with code `STREAM_ERROR` when exceeded.

## What changed

- **`src/client.ts`**: Added `MAX_SSE_BUFFER_SIZE` constant at module level. Added buffer size check inside the SSE read loop that throws `PolyforgeError` when the buffer exceeds 1 MB.
- **`src/__tests__/client.test.ts`**: Added 2 tests — one verifying the error is thrown for oversized payloads (>1 MB), one verifying normal payloads (<1 MB) still work correctly.
- **`CHANGELOG.md`**: Added `[1.19.1]` security entry.

## Test plan

- [x] Oversized SSE payload (>1 MB) throws `PolyforgeError` with code `STREAM_ERROR`
- [x] Normal-sized SSE payloads parse and yield events as before
- [x] All 180 existing tests still pass
- [x] `tsc --noEmit` (lint) passes
- [x] Full build passes

closes #43