### PR TITLE
fix(compat): use correct `period` param for getPriceHistory (closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.19.3] — 2026-04-15
+
+### Fixed
+- **Price history params** — `getPriceHistory()` now sends `period` (with values `"1h"`, `"6h"`, `"24h"`) instead of the incorrect `resolution` parameter. Removed unsupported `from`/`to` params that were silently ignored by the platform. (closes #116)
+
 ## [1.19.2] — 2026-04-15
 
 ### Security

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1610,11 +1610,9 @@ describe('Price history & order book (issue #52)', () => {
   });
 
   it('getPriceHistory passes query params', async () => {
-    await client.getPriceHistory('token-1', { resolution: '1d', from: '2026-01-01T00:00:00Z', to: '2026-01-31T00:00:00Z', limit: 100 });
+    await client.getPriceHistory('token-1', { period: '6h', limit: 100 });
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
-    expect(url.searchParams.get('resolution')).toBe('1d');
-    expect(url.searchParams.get('from')).toBe('2026-01-01T00:00:00Z');
-    expect(url.searchParams.get('to')).toBe('2026-01-31T00:00:00Z');
+    expect(url.searchParams.get('period')).toBe('6h');
     expect(url.searchParams.get('limit')).toBe('100');
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -800,9 +800,7 @@ export interface WebhookTestResult {
 // ── Price History & Order Book ──────────────────────────────────────────────
 
 export interface PriceHistoryParams {
-  resolution?: '1m' | '1h' | '1d';
-  from?: string;
-  to?: string;
+  period?: '1h' | '6h' | '24h';
   limit?: number;
 }
 


### PR DESCRIPTION
## Summary

- Renamed `resolution` → `period` in `PriceHistoryParams` interface
- Updated enum values from `'1m' | '1h' | '1d'` to `'1h' | '6h' | '24h'` to match platform's `PriceHistoryQueryDto`
- Removed unsupported `from`/`to` parameters (platform silently strips them via whitelist validation pipe)
- Updated tests to use correct param names and values

## Impact

Every `getPriceHistory()` call using `resolution` was silently falling back to the platform's default period. Users were getting unexpected OHLCV data with no error.

## Test plan

- [x] All 180 existing tests pass
- [x] Price history param test updated to use `period: '6h'`
- [x] TypeScript compilation clean
- [x] Build succeeds

closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)