### PR TITLE
fix(compat): correct ApiKeyScope, Alert direction, StrategyReportReason enums (closes #115, closes #117, closes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.19.4] — 2026-04-15
+
+### Fixed
+- **ApiKeyScope enum** — replaced phantom `STRATEGY`/`WEBHOOK` scopes with correct `WRITE` scope matching platform enum. (closes #115)
+- **Alert direction casing** — `CreateAlertParams.direction` and `Alert.direction` now use uppercase `'ABOVE' | 'BELOW'` matching platform validation. (closes #117)
+- **StrategyReportReason** — replaced non-existent `'HARMFUL'` with correct platform value `'INAPPROPRIATE'`. (closes #118)
+
 ## [1.19.3] — 2026-04-15
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -753,17 +753,17 @@ describe('CreateAlertParams matches platform DTO (#48)', () => {
   });
 
   it('sends { tokenId, direction, price } not { name, condition, marketId }', async () => {
-    const params: CreateAlertParams = { tokenId: 'tok-1', direction: 'above', price: '0.75' };
+    const params: CreateAlertParams = { tokenId: 'tok-1', direction: 'ABOVE', price: '0.75' };
     await client.createAlert(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ tokenId: 'tok-1', direction: 'above', price: '0.75' });
+    expect(body).toEqual({ tokenId: 'tok-1', direction: 'ABOVE', price: '0.75' });
     expect(body).not.toHaveProperty('name');
     expect(body).not.toHaveProperty('condition');
     expect(body).not.toHaveProperty('marketId');
   });
 
   it('sends persistent field when provided', async () => {
-    const params: CreateAlertParams = { tokenId: 'tok-1', direction: 'below', price: '0.25', persistent: true };
+    const params: CreateAlertParams = { tokenId: 'tok-1', direction: 'BELOW', price: '0.25', persistent: true };
     await client.createAlert(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('persistent', true);
@@ -773,14 +773,14 @@ describe('CreateAlertParams matches platform DTO (#48)', () => {
     const alert: Alert = {
       id: 'a-1',
       tokenId: 'tok-1',
-      direction: 'above',
+      direction: 'ABOVE',
       price: '0.75',
       persistent: false,
       enabled: true,
       createdAt: '2026-04-13T00:00:00Z',
     };
     expect(alert.tokenId).toBe('tok-1');
-    expect(alert.direction).toBe('above');
+    expect(alert.direction).toBe('ABOVE');
     expect(alert.price).toBe('0.75');
     expect((alert as any).name).toBeUndefined();
     expect((alert as any).condition).toBeUndefined();

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,7 @@ export interface NewsSignal {
 
 // ── API Keys ───────────────────────────────────────────────────────────────
 
-export type ApiKeyScope = 'READ' | 'TRADE' | 'STRATEGY' | 'WEBHOOK';
+export type ApiKeyScope = 'READ' | 'WRITE' | 'TRADE';
 
 export interface ApiKey {
   id: string;
@@ -238,7 +238,7 @@ export interface CreateApiKeyResponse extends Pick<ApiKey, 'id' | 'name' | 'pref
 export interface Alert {
   id: string;
   tokenId: string;
-  direction: 'above' | 'below';
+  direction: 'ABOVE' | 'BELOW';
   price: string;
   persistent: boolean;
   enabled: boolean;
@@ -629,7 +629,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'MISLEADING' | 'HARMFUL' | 'OTHER';
+export type StrategyReportReason = 'SPAM' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;
@@ -714,7 +714,7 @@ export interface RunBacktestParams {
 
 export interface CreateAlertParams {
   tokenId: string;
-  direction: 'above' | 'below';
+  direction: 'ABOVE' | 'BELOW';
   price: string;
   persistent?: boolean;
 }


### PR DESCRIPTION
## Summary
- **ApiKeyScope** (#115): Remove phantom `STRATEGY`/`WEBHOOK` scopes, add missing `WRITE` scope — users couldn't create write-capable API keys
- **Alert direction** (#117): Uppercase `ABOVE`/`BELOW` to match platform enum validation — all alert creation was failing with 422
- **StrategyReportReason** (#118): Replace non-existent `HARMFUL` with correct `INAPPROPRIATE` value

## Test plan
- [x] All 180 existing tests pass
- [x] Alert tests updated to use uppercase direction values
- [x] TypeScript build succeeds

closes #115, closes #117, closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)