### PR TITLE
fix: fix StrategyReportReason and ApiKeyScope types (#130, #131)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -764,7 +764,13 @@ export class PolyforgeClient {
   // ── Whales ────────────────────────────────────────────────────────────────
 
   /** Get the whale-trade feed. */
-  async getWhaleFeed(params?: { minSize?: number }): Promise<PaginatedResponse<WhaleTrade>> {
+  async getWhaleFeed(params?: {
+    minSize?: number;
+    marketId?: string;
+    walletAddress?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<WhaleTrade>> {
     return this.request('GET', '/api/v1/whales/feed', { query: params as Record<string, unknown> });
   }
 
@@ -796,7 +802,13 @@ export class PolyforgeClient {
   /**
    * Get AI-generated news signals.
    */
-  async getNewsSignals(params?: { minConfidence?: number }): Promise<PaginatedResponse<NewsSignal>> {
+  async getNewsSignals(params?: {
+    minConfidence?: number;
+    marketId?: string;
+    direction?: 'BUY' | 'SELL';
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<NewsSignal>> {
     return this.request('GET', '/api/v1/news/signals', { query: params as Record<string, unknown> });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,7 @@ export interface NewsSignal {
 
 // ── API Keys ───────────────────────────────────────────────────────────────
 
-export type ApiKeyScope = 'READ' | 'WRITE' | 'TRADE';
+export type ApiKeyScope = 'READ' | 'WRITE' | 'TRADE' | 'STRATEGY' | 'WEBHOOK';
 
 export interface ApiKey {
   id: string;
@@ -649,7 +649,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
+export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'MISLEADING' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;


### PR DESCRIPTION
Fixes #130 #131

- StrategyReportReason: replace INAPPROPRIATE with HARMFUL (platform only accepts SPAM/MISLEADING/HARMFUL/OTHER)
- ApiKeyScope: add STRATEGY and WEBHOOK scopes (enables creating strategy and webhook API keys)