### PR TITLE
fix(types): correct StrategyReportReason enum — HARMFUL→INAPPROPRIATE (#148)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1865,6 +1865,15 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(body).toEqual({ reason: 'OTHER', description: 'Looks suspicious' });
   });
 
+  it('reportStrategy accepts INAPPROPRIATE reason', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ reportId: 'r-2' }), { status: 201, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await client.reportStrategy('s-1', 'INAPPROPRIATE');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ reason: 'INAPPROPRIATE' });
+  });
+
   it('listStrategyVersions sends GET /api/v1/strategies/:id/versions', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify([{ id: 'v-1', version: 1 }]), { status: 200, headers: { 'Content-Type': 'application/json' } }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,7 +649,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'MISLEADING' | 'OTHER';
+export type StrategyReportReason = 'SPAM' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;


### PR DESCRIPTION
## Summary

- Fixes `StrategyReportReason` type: `HARMFUL` → `INAPPROPRIATE`
- The SDK's `HARMFUL` value matched the platform DTO's `@IsIn` guard but **not** the Prisma/PostgreSQL `ReportReason` enum — meaning any report with `HARMFUL` would pass API validation but fail at the database layer
- Adds a test for `INAPPROPRIATE` to lock in the correct value

## Root cause analysis

Three-layer inconsistency found during investigation:

| Layer | Values |
|---|---|
| Prisma/DB enum | `SPAM, INAPPROPRIATE, MISLEADING, OTHER` ✅ ground truth |
| Platform DTO `@IsIn` | `SPAM, MISLEADING, HARMFUL, OTHER` ⚠️ bug |
| SDK (before fix) | `SPAM, HARMFUL, MISLEADING, OTHER` ⚠️ followed DTO, not DB |

> The automated compatibility auditor (POLA-321) claimed the platform uses `OFFENSIVE/SCAM` — that was incorrect. The real issue is `HARMFUL` vs `INAPPROPRIATE`.

## Companion fix required

The platform DTO (`api-service/src/strategies/dto/report-strategy.dto.ts`) also needs `HARMFUL → INAPPROPRIATE`. Tracked in a new backend issue. **This SDK version should be released after the platform deploys the DTO fix**, otherwise `INAPPROPRIATE` will be rejected at the API validation layer.

## Test plan

- [x] `pnpm test` — 209 tests pass (1 new test added)
- [x] `pnpm build` — clean TypeScript compilation

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)