### PR TITLE
fix: add FAK and POST_ONLY to OrderType enum

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -986,22 +986,20 @@ describe('Market type uses title and tokens[] (#17)', () => {
   });
 });
 
-describe('OrderType uses platform values GTC/GTD/FOK (#36, #126)', () => {
-  it('should accept the 3 platform order types', () => {
-    const types: OrderType[] = ['GTC', 'GTD', 'FOK'];
-    expect(types).toHaveLength(3);
+describe('OrderType uses all 5 platform values (#36, #126, #153)', () => {
+  it('should accept all 5 platform order types', () => {
+    const types: OrderType[] = ['GTC', 'GTD', 'FOK', 'FAK', 'POST_ONLY'];
+    expect(types).toHaveLength(5);
   });
 
-  it('should not accept FAK or exchange-style order types', () => {
-    // Type-level check: these old values should NOT compile.
-    // Runtime check ensures the type is correctly constrained.
-    const validTypes = new Set<OrderType>(['GTC', 'GTD', 'FOK']);
+  it('should not accept exchange-style order types', () => {
+    const validTypes = new Set<OrderType>(['GTC', 'GTD', 'FOK', 'FAK', 'POST_ONLY']);
     expect(validTypes.has('GTC')).toBe(true);
     expect(validTypes.has('GTD')).toBe(true);
     expect(validTypes.has('FOK')).toBe(true);
-    // FAK is not accepted by the platform
-    expect(validTypes.has('FAK' as any)).toBe(false);
-    // Old values are no longer valid
+    expect(validTypes.has('FAK')).toBe(true);
+    expect(validTypes.has('POST_ONLY')).toBe(true);
+    // Old exchange-style values are not valid
     expect(validTypes.has('MARKET' as any)).toBe(false);
     expect(validTypes.has('LIMIT' as any)).toBe(false);
     expect(validTypes.has('STOP' as any)).toBe(false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type WebhookEvent =
   | 'PRICE_ALERT';
 
 export type OrderSide = 'BUY' | 'SELL';
-export type OrderType = 'GTC' | 'GTD' | 'FOK';
+export type OrderType = 'GTC' | 'GTD' | 'FOK' | 'FAK' | 'POST_ONLY';
 export type OrderStatus = 'PENDING' | 'SUBMITTED' | 'LIVE' | 'MATCHED' | 'DELAYED' | 'MINED' | 'CONFIRMED' | 'PARTIAL' | 'CANCELLED' | 'UNMATCHED' | 'FAILED' | 'ERROR';
 
 // ── Pagination ──────────────────────────────────────────────────────────────
@@ -416,7 +416,7 @@ export interface PlaceOrderParams {
   outcome: 'YES' | 'NO';
   size: number;
   price: number;
-  orderType?: 'GTC' | 'FOK' | 'GTD';
+  orderType?: OrderType;
 }
 
 export interface PlaceOrderResponse {


### PR DESCRIPTION
## Summary

- Adds `FAK` and `POST_ONLY` to the `OrderType` type union to match the platform's 5-value `OrderTypeDto` enum
- Updates `PlaceOrderParams.orderType` to reference the shared `OrderType` alias instead of an inline literal union (prevents future drift)
- Updates tests to validate all 5 platform order types

Closes #153

## Test plan

- [x] `pnpm lint` (tsc --noEmit) passes
- [x] `pnpm test` — 208 tests pass
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>