### PR TITLE
fix: align StrategyReportReason enum with platform contract

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1853,16 +1853,16 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toEqual({ reason: 'SPAM' });
-    expect(body).not.toHaveProperty('description');
+    expect(body).not.toHaveProperty('details');
   });
 
-  it('reportStrategy includes optional description', async () => {
+  it('reportStrategy includes optional details', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ reportId: 'r-1' }), { status: 201, headers: { 'Content-Type': 'application/json' } }),
     );
     await client.reportStrategy('s-1', 'OTHER', 'Looks suspicious');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ reason: 'OTHER', description: 'Looks suspicious' });
+    expect(body).toEqual({ reason: 'OTHER', details: 'Looks suspicious' });
   });
 
   it('listStrategyVersions sends GET /api/v1/strategies/:id/versions', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -669,9 +669,9 @@ export class PolyforgeClient {
   /**
    * Report a strategy for violating guidelines.
    */
-  async reportStrategy(id: string, reason: StrategyReportReason, description?: string): Promise<StrategyReportResult> {
+  async reportStrategy(id: string, reason: StrategyReportReason, details?: string): Promise<StrategyReportResult> {
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/report`, {
-      body: { reason, ...(description !== undefined && { description }) },
+      body: { reason, ...(details !== undefined && { details }) },
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -649,7 +649,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'MISLEADING' | 'OTHER';
+export type StrategyReportReason = 'OFFENSIVE' | 'SCAM' | 'SPAM' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;


### PR DESCRIPTION
## Summary

- **Fixes `StrategyReportReason` enum** — replaced `HARMFUL | MISLEADING` (rejected by platform) with `OFFENSIVE | SCAM` (actual platform values)
- **Renamed `description` → `details`** in `reportStrategy()` to match the platform DTO field name
- Updated tests to reflect the corrected contract

## Breaking Changes

- `StrategyReportReason` no longer includes `'HARMFUL'` or `'MISLEADING'` — use `'OFFENSIVE'` or `'SCAM'` instead
- `reportStrategy(id, reason, description?)` → `reportStrategy(id, reason, details?)` — parameter renamed

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 208 tests pass (`vitest run`)
- [ ] CI green

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)