### PR TITLE
fix(compat): replace PriceHistoryEntry with OHLCV PriceCandle type

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1680,6 +1680,33 @@ describe('Price history & order book (issue #52)', () => {
     expect(url.pathname).toContain('token%2Fspecial%26id');
   });
 
+  it('getPriceHistory returns OHLCV candles with bucket field', async () => {
+    const candle = { bucket: '2026-04-19T12:00:00.000Z', open: '0.65', high: '0.72', low: '0.63', close: '0.70', volume: 1500 };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify([candle]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const result = await client.getPriceHistory('token-1');
+    expect(result).toEqual([candle]);
+    expect(result[0].bucket).toBe('2026-04-19T12:00:00.000Z');
+    expect(result[0].open).toBe('0.65');
+    expect(result[0].close).toBe('0.70');
+    expect(result[0].volume).toBe(1500);
+  });
+
+  it('getPriceHistory accepts 5m and 15m resolutions', async () => {
+    await client.getPriceHistory('token-1', { resolution: '5m' });
+    let url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('resolution')).toBe('5m');
+
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await client.getPriceHistory('token-1', { resolution: '15m' });
+    url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('resolution')).toBe('15m');
+  });
+
   it('getOrderBook sends GET to /api/v1/markets/:tokenId/book', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ bids: [], asks: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),

--- a/src/client.ts
+++ b/src/client.ts
@@ -85,7 +85,7 @@ import type {
   WhaleTrade,
   WhaleTopParams,
   OrderBook,
-  PriceHistoryEntry,
+  PriceCandle,
   PriceHistoryParams,
   Backtest,
   ConditionalOrder,
@@ -460,7 +460,7 @@ export class PolyforgeClient {
   /**
    * Get price history for a market token.
    */
-  async getPriceHistory(tokenId: string, params?: PriceHistoryParams): Promise<PriceHistoryEntry[]> {
+  async getPriceHistory(tokenId: string, params?: PriceHistoryParams): Promise<PriceCandle[]> {
     return this.request('GET', `/api/v1/markets/${encodeURIComponent(tokenId)}/price-history`, {
       query: params as Record<string, unknown>,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export type {
   Portfolio,
   PolyforgeClientOptions,
   PortfolioPnl,
+  PriceCandle,
   PriceHistoryEntry,
   PriceHistoryParams,
   PortfolioPnlParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -827,17 +827,23 @@ export interface WebhookTestResult {
 // ── Price History & Order Book ──────────────────────────────────────────────
 
 export interface PriceHistoryParams {
-  resolution?: '1m' | '1h' | '1d';
+  resolution?: '1m' | '5m' | '15m' | '1h' | '1d';
   from?: string;
   to?: string;
   limit?: number;
 }
 
-export interface PriceHistoryEntry {
-  timestamp: string;
-  price: number;
-  volume?: number;
+export interface PriceCandle {
+  bucket: string;
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  volume: number;
 }
+
+/** @deprecated Use {@link PriceCandle} instead. */
+export type PriceHistoryEntry = PriceCandle;
 
 export interface OrderBookLevel {
   price: number;


### PR DESCRIPTION
## Summary

- Replace `PriceHistoryEntry` (`{timestamp, price, volume?}`) with `PriceCandle` (`{bucket, open, high, low, close, volume}`) to match the platform's actual OHLCV candle response shape
- Keep `PriceHistoryEntry` as a `@deprecated` type alias for backward compatibility
- Add missing `5m` and `15m` resolutions to `PriceHistoryParams`
- Add tests for OHLCV response shape and new resolution values

Closes #144

## Test plan

- [x] All 235 tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify `getPriceHistory()` returns properly typed `PriceCandle[]` against a live platform instance
- [ ] Confirm existing consumers using `PriceHistoryEntry` still compile (deprecated alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>