### PR TITLE
fix: redeemPosition return type uses positionId not orderId (#152)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2772,3 +2772,16 @@ describe('Rewards API', () => {
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
   });
 });
+
+describe('redeemPosition return type (#152)', () => {
+  it('redeemPosition returns positionId not orderId', async () => {
+    const redeemResponse = { positionId: 'pos-1', intentId: 'int-1', status: 'confirmed' };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(redeemResponse), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const result = await client.redeemPosition({ positionId: 'pos-1' });
+    expect(result).toHaveProperty('positionId', 'pos-1');
+    expect(result).toHaveProperty('intentId', 'int-1');
+    expect(result).not.toHaveProperty('orderId');
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,7 @@ import type {
   ProvideLiquidityParams,
   RateListingParams,
   RedeemPositionParams,
+  RedeemPositionResponse,
   SmartOrder,
   SpreadResult,
   SplitPositionParams,
@@ -1196,8 +1197,8 @@ export class PolyforgeClient {
   /**
    * Redeem winning shares after a market resolves.
    */
-  async redeemPosition(params: RedeemPositionParams): Promise<PlaceOrderResponse> {
-    return this.request('POST', '/api/v1/orders/redeem', { body: params });
+  async redeemPosition(params: RedeemPositionParams): Promise<RedeemPositionResponse> {
+    return this.request<RedeemPositionResponse>('POST', '/api/v1/orders/redeem', { body: params });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export type {
   Position,
   Rebate,
   RedeemPositionParams,
+  RedeemPositionResponse,
   RewardsMarket,
   RiskSettings,
   RunBacktestParams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -391,6 +391,12 @@ export interface RedeemPositionParams {
   marketId?: string;
 }
 
+export interface RedeemPositionResponse {
+  positionId: string;
+  intentId: string;
+  status: string;
+}
+
 export interface SplitPositionParams {
   tokenId: string;
   amount: string;


### PR DESCRIPTION
## Summary

- Added `RedeemPositionResponse` interface with `positionId`, `intentId`, `status` fields to match the platform `/api/v1/orders/redeem` response
- Updated `redeemPosition()` method signature from `Promise<PlaceOrderResponse>` to `Promise<RedeemPositionResponse>`
- Exported `RedeemPositionResponse` from `index.ts`
- Added contract test verifying response shape has `positionId` (not `orderId`)

**Breaking change:** consumers using `result.orderId` after `redeemPosition()` must switch to `result.positionId`.

Closes F4CTE/polyforge-sdk-ts#152

## Test plan

- [x] `pnpm lint` (tsc --noEmit) passes
- [x] `pnpm test` passes — 209 tests (1 new)
- [x] New test asserts `redeemPosition` returns `positionId`, not `orderId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)