### PR TITLE
fix(compat): add id field to BatchRequestItem and BatchResponse results

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2220,7 +2220,7 @@ describe('Batch API (#66)', () => {
   beforeEach(() => {
     client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
-      new Response(JSON.stringify({ results: [{ status: 200, body: {} }] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify({ results: [{ id: 'req-1', status: 200, body: {} }, { id: 'req-2', status: 200, body: {} }] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
   });
 
@@ -2229,17 +2229,20 @@ describe('Batch API (#66)', () => {
   });
 
   it('batchRequests sends POST to /api/v1/batch with items array', async () => {
-    await client.batchRequests([
-      { method: 'GET', path: '/api/v1/portfolio' },
-      { method: 'GET', path: '/api/v1/strategies' },
+    const res = await client.batchRequests([
+      { id: 'req-1', method: 'GET', path: '/api/v1/portfolio' },
+      { id: 'req-2', method: 'GET', path: '/api/v1/strategies' },
     ]);
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toBe('/api/v1/batch');
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body.items).toHaveLength(2);
+    expect(body.items[0].id).toBe('req-1');
     expect(body.items[0].method).toBe('GET');
     expect(body.items[0].path).toBe('/api/v1/portfolio');
+    expect(res.results[0].id).toBe('req-1');
+    expect(res.results[1].id).toBe('req-2');
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -906,6 +906,7 @@ export interface PaperSummary {
 // ── Batch API ───────────────────────────────────────────────────────────────
 
 export interface BatchRequestItem {
+  id: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
   path: string;
   body?: Record<string, unknown>;
@@ -913,6 +914,7 @@ export interface BatchRequestItem {
 
 export interface BatchResponse {
   results: Array<{
+    id: string;
     status: number;
     body: unknown;
   }>;


### PR DESCRIPTION
## Summary
- Adds required `id: string` field to `BatchRequestItem` so each batch item can be uniquely identified
- Adds `id: string` to each entry in `BatchResponse.results[]` so clients can correlate responses to requests deterministically (not just by array position)
- Updates batch API tests to verify `id` is sent in requests and preserved in responses

Closes #154 / POLA-317

## Test plan
- [x] All 233 existing tests pass
- [x] TypeScript strict typecheck passes (`tsc --noEmit`)
- [x] Batch test now verifies `id` round-trips through request and response

🤖 Generated with [Claude Code](https://claude.com/claude-code)