### PR TITLE
fix(compat): nest PaginatedResponse pagination fields under pagination object (closes #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.19.5] — 2026-04-21
+
+### Fixed
+- **PaginatedResponse shape** — `PaginatedResponse<T>` now nests pagination metadata under a `pagination` sub-object (`{ page, limit, total, totalPages }`) to match the platform contract. The flat top-level fields (`total`, `page`, `limit`, `totalPages`) and the non-existent `hasNext` field have been removed. Any code accessing `response.total` or `response.hasNext` must be updated to use `response.pagination.total`, etc. (closes #141)
+
 ## [1.19.4] — 2026-04-15
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -527,35 +527,37 @@ describe('StrategyStatusResponse type (#61)', () => {
   });
 });
 
-describe('PaginatedResponse type (#78)', () => {
-  it('should correctly type a paginated strategy response', () => {
+describe('PaginatedResponse type (#78, #141)', () => {
+  it('should correctly type a paginated strategy response with nested pagination', () => {
     const resp: PaginatedResponse<Strategy> = {
       data: [
         { id: 's1', name: 'Alpha', status: 'IDLE' as StrategyStatus, visibility: 'PRIVATE', execMode: 'TICK', tickMs: 1000, triggers: [], conditions: [], actions: [], safety: [], logicBlocks: [], calcBlocks: [], tags: [], variables: [], pnl: 0, tradeCount: 0, winRate: 0, createdAt: '', updatedAt: '' },
       ],
-      total: 1,
-      page: 1,
-      limit: 10,
-      totalPages: 1,
-      hasNext: false,
+      pagination: { total: 1, page: 1, limit: 10, totalPages: 1 },
     };
     expect(resp.data).toHaveLength(1);
     expect(resp.data[0].id).toBe('s1');
-    expect(resp.total).toBe(1);
-    expect(resp.hasNext).toBe(false);
+    expect(resp.pagination.total).toBe(1);
+    expect(resp.pagination.page).toBe(1);
+    expect(resp.pagination.limit).toBe(10);
+    expect(resp.pagination.totalPages).toBe(1);
   });
 
   it('should have correct shape for empty response', () => {
     const resp: PaginatedResponse<Strategy> = {
       data: [],
-      total: 0,
-      page: 1,
-      limit: 10,
-      totalPages: 0,
-      hasNext: false,
+      pagination: { total: 0, page: 1, limit: 10, totalPages: 0 },
     };
     expect(resp.data).toHaveLength(0);
-    expect(resp.total).toBe(0);
+    expect(resp.pagination.total).toBe(0);
+  });
+
+  it('should not have hasNext field (not part of platform contract)', () => {
+    const resp: PaginatedResponse<Strategy> = {
+      data: [],
+      pagination: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    };
+    expect((resp as any).hasNext).toBeUndefined();
   });
 });
 
@@ -1312,7 +1314,7 @@ describe('Missing query parameters on list methods', () => {
   beforeEach(() => {
     client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
-      new Response(JSON.stringify({ data: [], total: 0, page: 1, limit: 10, totalPages: 0, hasNext: false }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify({ data: [], pagination: { total: 0, page: 1, limit: 10, totalPages: 0 } }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
   });
 
@@ -1797,7 +1799,7 @@ describe('Strategy social + versioning endpoints (#54)', () => {
   });
 
   it('listStrategyComments sends GET /api/v1/strategies/:id/comments with pagination', async () => {
-    const resp = { data: [], total: 0, page: 1, limit: 20, totalPages: 0, hasNext: false };
+    const resp = { data: [], pagination: { total: 0, page: 1, limit: 20, totalPages: 0 } };
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify(resp), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,11 +20,12 @@ export type OrderStatus = 'PENDING' | 'SUBMITTED' | 'LIVE' | 'MATCHED' | 'DELAYE
 
 export interface PaginatedResponse<T> {
   data: T[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-  hasNext: boolean;
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
 }
 
 // ── Markets ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `PaginatedResponse<T>` now matches the platform contract: pagination metadata is nested under a `pagination` sub-object (`{ page, limit, total, totalPages }`)
- Removed flat top-level fields (`total`, `page`, `limit`, `totalPages`) that were silently `undefined` at runtime
- Removed `hasNext` field which does not exist on the platform at all
- Updated type-shape tests and all mock response fixtures to use the nested shape
- 209 tests passing, `tsc --noEmit` clean

## Breaking change

Any caller accessing `response.total`, `response.page`, `response.limit`, `response.totalPages`, or `response.hasNext` must update to `response.pagination.total`, etc.

## Test plan

- [x] `tsc --noEmit` passes with no type errors
- [x] `vitest run` — 209/209 tests passing
- [x] New tests assert nested `pagination` object shape and absence of `hasNext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)