### PR TITLE
fix(tests): resolve 3 TS errors in client.test.ts (POLA-706)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vite:
-        specifier: ^8.0.8
+        specifier: '>=8.0.5'
         version: 8.0.8(@types/node@20.19.39)
       vitest:
         specifier: ^4.1.2

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1923,13 +1923,13 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(body).toEqual({ reason: 'OTHER', description: 'Looks suspicious' });
   });
 
-  it('reportStrategy accepts INAPPROPRIATE reason', async () => {
+  it('reportStrategy accepts MISLEADING reason', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ reportId: 'r-2' }), { status: 201, headers: { 'Content-Type': 'application/json' } }),
     );
-    await client.reportStrategy('s-1', 'INAPPROPRIATE');
+    await client.reportStrategy('s-1', 'MISLEADING');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ reason: 'INAPPROPRIATE' });
+    expect(body).toEqual({ reason: 'MISLEADING' });
   });
 
   it('listStrategyVersions sends GET /api/v1/strategies/:id/versions', async () => {
@@ -2774,6 +2774,20 @@ describe('Rewards API', () => {
 });
 
 describe('redeemPosition return type (#152)', () => {
+  let client: PolyforgeClient;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
   it('redeemPosition returns positionId not orderId', async () => {
     const redeemResponse = { positionId: 'pos-1', intentId: 'int-1', status: 'confirmed' };
     fetchSpy.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Replace stale `INAPPROPRIATE` enum value with valid `MISLEADING` in `reportStrategy` test — `StrategyReportReason` no longer includes `INAPPROPRIATE`
- Add missing `client`/`fetchSpy` setup (`let`, `beforeEach`, `afterEach`) to `redeemPosition` describe block that was orphaned outside its parent scope
- Fixes main-branch CI: all 248 tests pass, typecheck clean, build clean

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (was 3)
- [x] `npx vitest run` — 248/248 pass
- [x] `npx tsc --build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)