### PR TITLE
fix(security): enforce response body cap while streaming

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3397,6 +3397,31 @@ describe('response body size limit (#184)', () => {
     fetchSpy?.mockRestore();
   });
 
+  function oversizedStream(prefix = '', suffix = ''): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    let emitted = 0;
+    const chunk = encoder.encode('x'.repeat(1024 * 1024));
+
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (prefix) {
+          controller.enqueue(encoder.encode(prefix));
+        }
+      },
+      pull(controller) {
+        if (emitted <= 10) {
+          controller.enqueue(chunk);
+          emitted += 1;
+          return;
+        }
+        if (suffix) {
+          controller.enqueue(encoder.encode(suffix));
+        }
+        controller.close();
+      },
+    });
+  }
+
   it('rejects responses with Content-Length exceeding 10 MB', async () => {
     const tenMbPlusOne = 10 * 1024 * 1024 + 1;
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -3461,6 +3486,49 @@ describe('response body size limit (#184)', () => {
 
     // No Content-Length — should fall through to response.json() normally
     await expect(client.listMarkets()).resolves.toBeDefined();
+  });
+
+  it('rejects oversized JSON responses without Content-Length', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(oversizedStream('{"data":"', '"}'), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(client.listMarkets()).rejects.toMatchObject({
+      code: 'RESPONSE_BODY_TOO_LARGE',
+    });
+  });
+
+  it('rejects CSV responses with Content-Length exceeding 10 MB', async () => {
+    const tenMbPlusOne = 10 * 1024 * 1024 + 1;
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('id,marketId\norder-1,mkt-1', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv',
+          'Content-Length': String(tenMbPlusOne),
+        },
+      }),
+    );
+
+    await expect(client.exportOrdersCsv()).rejects.toMatchObject({
+      code: 'RESPONSE_BODY_TOO_LARGE',
+    });
+  });
+
+  it('rejects oversized CSV responses without Content-Length', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(oversizedStream('id,marketId\n'), {
+        status: 200,
+        headers: { 'Content-Type': 'text/csv' },
+      }),
+    );
+
+    await expect(client.exportOrdersCsv()).rejects.toMatchObject({
+      code: 'RESPONSE_BODY_TOO_LARGE',
+    });
   });
 
   it('also guards error response bodies with Content-Length > 10 MB', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -367,22 +367,58 @@ export class PolyforgeClient {
 
   /**
    * Read response body as JSON with size guard.
-   * Checks Content-Length header; if present and exceeds MAX_RESPONSE_BODY_SIZE, throws.
-   * Falls back to streaming byte count when Content-Length is absent.
+   * Checks Content-Length first, then enforces the same limit while reading.
    */
   private async safeJson<R>(response: Response): Promise<R> {
+    return JSON.parse(await this.readResponseText(response)) as R;
+  }
+
+  private throwResponseBodyTooLarge(status: number, size: number): never {
+    throw new PolyforgeError({
+      status,
+      code: 'RESPONSE_BODY_TOO_LARGE',
+      message: `Response body too large (${size} bytes, limit ${MAX_RESPONSE_BODY_SIZE})`,
+    });
+  }
+
+  private async readResponseText(response: Response): Promise<string> {
     const cl = response.headers.get('content-length');
     if (cl) {
       const size = parseInt(cl, 10);
       if (!Number.isNaN(size) && size > MAX_RESPONSE_BODY_SIZE) {
-        throw new PolyforgeError({
-          status: response.status,
-          code: 'RESPONSE_BODY_TOO_LARGE',
-          message: `Response body too large (${size} bytes, limit ${MAX_RESPONSE_BODY_SIZE})`,
-        });
+        this.throwResponseBodyTooLarge(response.status, size);
       }
     }
-    return (await response.json()) as R;
+
+    if (!response.body) {
+      return '';
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let size = 0;
+    let body = '';
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        size += value.byteLength;
+        if (size > MAX_RESPONSE_BODY_SIZE) {
+          await reader.cancel().catch(() => undefined);
+          this.throwResponseBodyTooLarge(response.status, size);
+        }
+
+        body += decoder.decode(value, { stream: true });
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return body + decoder.decode();
   }
 
   private async request<T>(
@@ -487,7 +523,7 @@ export class PolyforgeClient {
       });
     }
 
-    return response.text();
+    return this.readResponseText(response);
   }
 
   // ── Markets ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Enforce the 10 MB response body cap while streaming response bodies, not just via `Content-Length`.
- Route JSON and CSV/text response reads through the same guarded reader.
- Add regression coverage for oversized JSON without `Content-Length`, oversized CSV with `Content-Length`, and oversized CSV without `Content-Length`.

Closes #186

## Verification
- RED: `npx vitest run src/__tests__/client.test.ts -t "response body size limit"` failed for the three new regression cases before the implementation.
- `npm run lint`
- `npm test -- --run src/__tests__/client.test.ts -t "response body size limit" --reporter=dot`
- `npm test -- --run src/__tests__/client.test.ts --reporter=dot`
- `npm run build`
- `git diff --check`
- Added-line static scan for hardcoded secrets and common injection patterns: no findings.
- GitNexus impact: `request`/`safeJson` CRITICAL shared request path, `requestText` LOW with 2 direct CSV callers.
- GitNexus detect changes: 2 changed files, expected request/response flows affected; coarse symbol mapping reported CRITICAL due centralized client request surface.
