### PR TITLE
chore(security): remove committed node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/f4cte/polyforge-sdk-ts/node_modules


### PR DESCRIPTION
## Summary
- remove the tracked root `node_modules` symlink that pointed to an absolute local path
- keep dependency installation controlled by package manager output and existing `.gitignore`

## Verification
- `npm ci --include=dev --ignore-scripts`
- `npm test -- --run`
- `npm run build`
- `npm audit signatures` still reports no supported registry-installed dependencies in this environment, but no longer emits an npm reify warning about removing a non-directory `node_modules` path

Closes #187