### PR TITLE
fix(sdk): align UpdateSettingsProfileParams with platform DTO (closes #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@
   `ComboCollection`, `ComboCollectionsPage`, `ComboLookupLeg`,
   `ComboLookupParams`, `ComboTickerLookup`, `CorrelationCategoriesReport`).
 
+### Fixed
+- **`UpdateSettingsProfileParams` shape** — removed the phantom `username`
+  field (the platform's `PATCH /api/v1/settings/profile` does not whitelist
+  `username` and `forbidNonWhitelisted` rejects any payload containing it
+  with HTTP 400) and added the missing `twitterHandle` field, matching the
+  platform `UpdateProfileDto`. To change a username, use the appropriate
+  public-profile endpoint instead — it does not belong on the settings
+  profile patch. The `updateSettingsProfile` doc-comment was also corrected
+  to no longer advertise `username`. Restores SDK-to-SDK parity with
+  sdk-python's `update_settings_profile(twitter_handle=...)`. A regression
+  test now asserts the serialized PATCH body contains exactly the four
+  whitelisted fields and never contains `username`. (closes #192)
+
 ## [1.19.5] — 2026-04-21
 
 ### Fixed

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3261,13 +3261,27 @@ describe('Settings endpoints (POLA-780)', () => {
 
   afterEach(() => { fetchSpy.mockRestore(); });
 
-  it('updateSettingsProfile sends PATCH /api/v1/settings/profile', async () => {
-    await client.updateSettingsProfile({ username: 'newname', displayName: 'New Name' });
+  it('updateSettingsProfile sends PATCH /api/v1/settings/profile with platform-whitelisted fields only', async () => {
+    await client.updateSettingsProfile({
+      displayName: 'New Name',
+      bio: 'New bio',
+      avatarUrl: 'https://cdn.example.com/me.png',
+      twitterHandle: 'newhandle',
+    });
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(new URL(url).pathname).toBe('/api/v1/settings/profile');
     expect(init.method).toBe('PATCH');
     const body = JSON.parse(init.body as string);
-    expect(body.username).toBe('newname');
+    expect(body).toEqual({
+      displayName: 'New Name',
+      bio: 'New bio',
+      avatarUrl: 'https://cdn.example.com/me.png',
+      twitterHandle: 'newhandle',
+    });
+    // Regression guard for the phantom `username` field (POLA-1991 / sdk-ts#192):
+    // the platform DTO does not whitelist `username`, and `forbidNonWhitelisted`
+    // makes any payload containing it return HTTP 400.
+    expect(body).not.toHaveProperty('username');
   });
 
   it('getNotificationSettings calls GET /api/v1/settings/notifications', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1703,7 +1703,14 @@ export class PolyforgeClient {
 
   // ── Settings ─────────────────────────────────────────────────────────────
 
-  /** Update the authenticated user's settings profile (username, display name, etc.). */
+  /**
+   * Update the authenticated user's settings profile.
+   *
+   * Mirrors the platform's `PATCH /api/v1/settings/profile` whitelist
+   * (`UpdateProfileDto`): `displayName`, `bio`, `avatarUrl`, `twitterHandle`.
+   * `username` is intentionally not on this endpoint — the platform rejects
+   * unknown fields with HTTP 400 (`forbidNonWhitelisted`).
+   */
   async updateSettingsProfile(params: UpdateSettingsProfileParams): Promise<void> {
     return this.request('PATCH', '/api/v1/settings/profile', { body: params });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1264,9 +1264,9 @@ export interface FollowResult {
 
 export interface UpdateSettingsProfileParams {
   displayName?: string;
-  username?: string;
   bio?: string;
   avatarUrl?: string;
+  twitterHandle?: string;
 }
 
 export interface NotificationSettings {


### PR DESCRIPTION
## Problem

`UpdateSettingsProfileParams` does not match the platform's
`PATCH /api/v1/settings/profile` whitelist (`UpdateProfileDto`):

* It declares a phantom `username` field. The platform DTO does not whitelist
  `username`, and `forbidNonWhitelisted: true` makes any payload containing it
  return HTTP 400. The SDK type silently invites a broken call.
* It is missing the platform's `twitterHandle` field, so users cannot set or
  clear their X/Twitter handle through sdk-ts at all. This field is reachable
  from sdk-python (`update_settings_profile(twitter_handle=...)`) and the MCP
  server (`update_settings_profile` tool), creating an SDK-to-SDK parity gap.

The existing test was actively cementing the wrong contract — it sent
`username: 'newname'` and asserted the wire body included it, exactly the
shape the platform now rejects.

## What changed

* `src/types.ts` — `UpdateSettingsProfileParams` now mirrors the platform DTO:
  `displayName?`, `bio?`, `avatarUrl?`, `twitterHandle?`. `username` removed.
* `src/client.ts` — corrected the `updateSettingsProfile` doc-comment, which
  still advertised `username` as a supported field, and documented the
  intentional whitelist alignment.
* `src/__tests__/client.test.ts` — replaced the broken test with one that
  sends all four whitelisted fields, deep-equality checks the serialized PATCH
  body, and adds an explicit `expect(body).not.toHaveProperty('username')`
  regression guard.
* `CHANGELOG.md` — `[Unreleased]` entry under **Fixed**.

## Behaviour

* Existing callers that *only* used `displayName` / `bio` / `avatarUrl` are
  unaffected. (Compile-time only — no runtime change to the request shape.)
* Callers that pass `username` will now fail TypeScript compilation, surfacing
  the latent HTTP 400 at build time. This is the intended behaviour: if
  username changes are a real product requirement, they belong on a separate
  public-profile / users endpoint, not on `PATCH /settings/profile`.
* Callers can now set `twitterHandle` and reach SDK parity with sdk-python
  and the MCP server.

## Verification

```
pnpm lint   # tsc --noEmit — clean
pnpm test   # 295/295 passing
pnpm build  # tsc + ESM emit — clean
```

Closes F4CTE/polyforge-sdk-ts#192
Refs POLA-1991