### PR TITLE
fix(sdk): align NotificationSettings with platform DTO (closes #191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,28 @@
   sdk-python's `update_settings_profile(twitter_handle=...)`. A regression
   test now asserts the serialized PATCH body contains exactly the four
   whitelisted fields and never contains `username`. (closes #192)
+- **`NotificationSettings` / `UpdateNotificationSettingsParams` shape** —
+  rewrote both interfaces to match the platform's `UpdateNotificationsDto`
+  for `GET/PATCH /api/v1/settings/notifications` exactly. The previous
+  shape used phantom `emailOnOrderFilled`/`emailOnStrategyError`/
+  `emailOnDailyLossLimit`/`emailOnMarketResolved`/`pushOnOrderFilled`/
+  `pushOnStrategyError`/`pushOnWhaleAlert`/`pushOnPriceAlert` fields that
+  do not exist on the platform DTO, so every call to
+  `client.updateNotificationSettings(...)` was rejected with HTTP 400 by
+  the platform's `forbidNonWhitelisted` validator (and `getNotificationSettings()`
+  silently returned an object with all-undefined declared fields). The new
+  shape exposes the platform's three channel toggles (`emailEnabled`,
+  `telegramEnabled`, `discordEnabled`) and per-event toggles (`onOrderFilled`,
+  `onStrategyError`, `onBacktestComplete`, `onDailyLossLimit`, `onMarketResolved`,
+  `onSomeoneForked`, `onSomeoneFollowed`, `onSomeoneLiked`, `onSomeoneCommented`),
+  unblocking Telegram/Discord toggles and several event toggles that were
+  previously unreachable from sdk-ts. `UpdateNotificationSettingsParams` is
+  now `Partial<NotificationSettings>`. Restores parity with the MCP server's
+  `update_settings_notifications` tool. Tests now assert exact wire-body
+  equality and a regression guard explicitly forbids the old phantom field
+  names. **Breaking change** for anyone who was reading or sending the old
+  field names (which never worked against the live platform anyway).
+  (closes #191)
 
 ## [1.19.5] — 2026-04-21
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3284,12 +3284,24 @@ describe('Settings endpoints (POLA-780)', () => {
     expect(body).not.toHaveProperty('username');
   });
 
-  it('getNotificationSettings calls GET /api/v1/settings/notifications', async () => {
+  it('getNotificationSettings deserializes the platform NotificationSettings shape', async () => {
+    // Fixture matches the platform UpdateNotificationsDto exactly (channel
+    // toggles + per-event `onXxx` toggles). The previous fixture used the
+    // SDK's old phantom `emailOn*`/`pushOn*` names — exactly the broken
+    // contract this fix closes (POLA-1996 / sdk-ts#191).
     const mockSettings = {
-      emailOnOrderFilled: true, emailOnStrategyError: false,
-      emailOnDailyLossLimit: true, emailOnMarketResolved: false,
-      pushOnOrderFilled: true, pushOnStrategyError: true,
-      pushOnWhaleAlert: false, pushOnPriceAlert: false,
+      emailEnabled: true,
+      telegramEnabled: false,
+      discordEnabled: true,
+      onOrderFilled: true,
+      onStrategyError: false,
+      onBacktestComplete: true,
+      onDailyLossLimit: false,
+      onMarketResolved: true,
+      onSomeoneForked: false,
+      onSomeoneFollowed: true,
+      onSomeoneLiked: false,
+      onSomeoneCommented: true,
     };
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify(mockSettings), { status: 200, headers: { 'Content-Type': 'application/json' } }),
@@ -3298,19 +3310,61 @@ describe('Settings endpoints (POLA-780)', () => {
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toBe('/api/v1/settings/notifications');
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
-    expect(result.emailOnOrderFilled).toBe(true);
+    expect(result).toEqual(mockSettings);
   });
 
-  it('updateNotificationSettings sends PATCH /api/v1/settings/notifications', async () => {
+  it('updateNotificationSettings sends PATCH /api/v1/settings/notifications with platform-whitelisted fields only', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
-    await client.updateNotificationSettings({ pushOnWhaleAlert: true });
+    await client.updateNotificationSettings({
+      emailEnabled: true,
+      telegramEnabled: false,
+      discordEnabled: true,
+      onOrderFilled: true,
+      onStrategyError: false,
+      onBacktestComplete: true,
+      onDailyLossLimit: false,
+      onMarketResolved: true,
+      onSomeoneForked: false,
+      onSomeoneFollowed: true,
+      onSomeoneLiked: false,
+      onSomeoneCommented: true,
+    });
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(new URL(url).pathname).toBe('/api/v1/settings/notifications');
     expect(init.method).toBe('PATCH');
     const body = JSON.parse(init.body as string);
-    expect(body.pushOnWhaleAlert).toBe(true);
+    expect(body).toEqual({
+      emailEnabled: true,
+      telegramEnabled: false,
+      discordEnabled: true,
+      onOrderFilled: true,
+      onStrategyError: false,
+      onBacktestComplete: true,
+      onDailyLossLimit: false,
+      onMarketResolved: true,
+      onSomeoneForked: false,
+      onSomeoneFollowed: true,
+      onSomeoneLiked: false,
+      onSomeoneCommented: true,
+    });
+    // Regression guard for the phantom `emailOn*` / `pushOn*` fields
+    // (POLA-1996 / sdk-ts#191): the platform DTO does not whitelist any of
+    // them, and `forbidNonWhitelisted` makes any payload containing them
+    // return HTTP 400. Verify none of the old shapes leak into the wire body.
+    for (const phantom of [
+      'emailOnOrderFilled',
+      'emailOnStrategyError',
+      'emailOnDailyLossLimit',
+      'emailOnMarketResolved',
+      'pushOnOrderFilled',
+      'pushOnStrategyError',
+      'pushOnWhaleAlert',
+      'pushOnPriceAlert',
+    ]) {
+      expect(body).not.toHaveProperty(phantom);
+    }
   });
 
   it('changePassword sends PATCH /api/v1/settings/password', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1269,27 +1269,33 @@ export interface UpdateSettingsProfileParams {
   twitterHandle?: string;
 }
 
+/**
+ * Notification settings as exposed by `GET/PATCH /api/v1/settings/notifications`.
+ *
+ * Mirrors the platform `UpdateNotificationsDto`
+ * (`services/api-service/src/settings/dto/update-notifications.dto.ts`):
+ * three channel toggles (`emailEnabled`, `telegramEnabled`, `discordEnabled`)
+ * plus per-event toggles named `onXxx`. The platform's global
+ * `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true })` rejects
+ * any field not listed here with HTTP 400 — so this interface must stay an
+ * exact mirror of the DTO. (closes #191)
+ */
 export interface NotificationSettings {
-  emailOnOrderFilled: boolean;
-  emailOnStrategyError: boolean;
-  emailOnDailyLossLimit: boolean;
-  emailOnMarketResolved: boolean;
-  pushOnOrderFilled: boolean;
-  pushOnStrategyError: boolean;
-  pushOnWhaleAlert: boolean;
-  pushOnPriceAlert: boolean;
+  emailEnabled?: boolean;
+  telegramEnabled?: boolean;
+  discordEnabled?: boolean;
+  onOrderFilled?: boolean;
+  onStrategyError?: boolean;
+  onBacktestComplete?: boolean;
+  onDailyLossLimit?: boolean;
+  onMarketResolved?: boolean;
+  onSomeoneForked?: boolean;
+  onSomeoneFollowed?: boolean;
+  onSomeoneLiked?: boolean;
+  onSomeoneCommented?: boolean;
 }
 
-export interface UpdateNotificationSettingsParams {
-  emailOnOrderFilled?: boolean;
-  emailOnStrategyError?: boolean;
-  emailOnDailyLossLimit?: boolean;
-  emailOnMarketResolved?: boolean;
-  pushOnOrderFilled?: boolean;
-  pushOnStrategyError?: boolean;
-  pushOnWhaleAlert?: boolean;
-  pushOnPriceAlert?: boolean;
-}
+export type UpdateNotificationSettingsParams = Partial<NotificationSettings>;
 
 export interface ChangePasswordSettingsParams {
   currentPassword: string;


### PR DESCRIPTION
## Summary

The TypeScript SDK's `NotificationSettings` and `UpdateNotificationSettingsParams` types did not match the platform's `UpdateNotificationsDto` at all. The SDK exposed phantom `emailOn*` / `pushOn*` fields, but the platform expects channel toggles (`emailEnabled`, `telegramEnabled`, `discordEnabled`) plus per-event toggles named `onXxx`. With the platform's global `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true })`, every field the SDK previously sent was rejected with HTTP 400 — the entire `PATCH /api/v1/settings/notifications` endpoint was unreachable from sdk-ts, and `getNotificationSettings()` silently deserialized the platform's actual response into an object whose declared fields were all `undefined`.

This PR rewrites both interfaces to mirror the platform DTO exactly, restoring SDK-to-SDK parity with the MCP server's `update_settings_notifications` tool.

## What changed

- `src/types.ts`
  - `NotificationSettings`: replaced eight phantom `emailOn*` / `pushOn*` fields with the platform's twelve actual fields (three channel toggles + nine per-event toggles), all optional to match the GET response (the platform may omit channel toggles for users who haven't set them).
  - `UpdateNotificationSettingsParams`: collapsed to ``Partial<NotificationSettings>`` so the two shapes can never drift again.
  - Added a doc-comment explaining why this interface must stay an exact mirror of the DTO.
- `src/__tests__/client.test.ts`
  - Updated `getNotificationSettings` test fixture from the old phantom shape to the platform shape; assertion is now a deep-equality check on the full deserialized object.
  - Updated `updateNotificationSettings` test to send all twelve whitelisted fields and assert the wire body matches exactly.
  - Added a regression guard that loops through all eight phantom field names and asserts the wire body never contains any of them.
- `CHANGELOG.md`: documented under \`[Unreleased]\` as a (breaking) fix, listing dropped/added fields and the reason.

## Test plan

- [x] `pnpm lint` (\`tsc --noEmit\`) — clean
- [x] `pnpm test` (vitest) — 295 / 295 passing, including the two updated notification-settings tests + the new regression guard
- [x] `pnpm build` — clean (\`tsc\` + ESM emit)

Refs: POLA-1996, closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)