### PR TITLE
fix(compat): startStrategy sends { mode } not { paperMode, deploymentMode } (closes #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
   names. **Breaking change** for anyone who was reading or sending the old
   field names (which never worked against the live platform anyway).
   (closes #191)
+- **`startStrategy` wire format** — `startStrategy` now sends `{ mode: 'live' | 'paper' }` to match the platform `StartStrategyDto` (`@IsIn(["live", "paper"])`). Previously the SDK sent `{ paperMode, deploymentMode }`, which the platform rejected with a validation error. The legacy `paperMode` boolean is still accepted as input for backward compatibility (translated to `mode` before dispatch) but is now `@deprecated`; prefer `mode`. The legacy `deploymentMode` field has never been accepted by the platform and is silently dropped. (closes polyforge-sdk-ts#190, regression of #179)
 
 ## [1.19.5] — 2026-04-21
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -173,28 +173,48 @@ describe('Platform contract compliance', () => {
     expect(body).not.toHaveProperty('query');
   });
 
-  it('startStrategy sends paperMode:false for live (#145)', async () => {
-    await client.startStrategy('strat-id', { paperMode: false });
+  it('startStrategy sends { mode: "live" } when mode:"live" (#190)', async () => {
+    await client.startStrategy('strat-id', { mode: 'live' });
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ paperMode: false });
+    expect(body).toEqual({ mode: 'live' });
   });
 
-  it('startStrategy sends paperMode:true for paper (#145)', async () => {
-    await client.startStrategy('strat-id', { paperMode: true });
+  it('startStrategy sends { mode: "paper" } when mode:"paper" (#190)', async () => {
+    await client.startStrategy('strat-id', { mode: 'paper' });
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ paperMode: true });
+    expect(body).toEqual({ mode: 'paper' });
   });
 
-  it('startStrategy sends deploymentMode when provided (#145)', async () => {
-    await client.startStrategy('strat-id', { paperMode: false, deploymentMode: 'LIVE' });
-    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ paperMode: false, deploymentMode: 'LIVE' });
-  });
-
-  it('startStrategy defaults to paperMode:true (#145)', async () => {
+  it('startStrategy defaults to { mode: "paper" } (#190)', async () => {
     await client.startStrategy('strat-id');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body).toEqual({ paperMode: true });
+    expect(body).toEqual({ mode: 'paper' });
+  });
+
+  it('startStrategy translates legacy paperMode:false to { mode: "live" } (#190)', async () => {
+    await client.startStrategy('strat-id', { paperMode: false });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'live' });
+  });
+
+  it('startStrategy translates legacy paperMode:true to { mode: "paper" } (#190)', async () => {
+    await client.startStrategy('strat-id', { paperMode: true });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'paper' });
+  });
+
+  it('startStrategy drops legacy deploymentMode and never sends paperMode/deploymentMode (#190)', async () => {
+    await client.startStrategy('strat-id', { paperMode: false, deploymentMode: 'LIVE' });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'live' });
+    expect(body).not.toHaveProperty('paperMode');
+    expect(body).not.toHaveProperty('deploymentMode');
+  });
+
+  it('startStrategy prefers mode over legacy paperMode when both are passed (#190)', async () => {
+    await client.startStrategy('strat-id', { mode: 'live', paperMode: true });
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ mode: 'live' });
   });
 
   it('placeSmartOrder sends intervalMinutes not intervalSeconds (#88)', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -729,14 +729,35 @@ export class PolyforgeClient {
   }
 
   /**
-   * Start a strategy. Defaults to paper mode (paperMode: true) for safety.
+   * Start a strategy. Defaults to paper mode (`mode: 'paper'`) for safety.
+   *
+   * The platform expects `{ mode: 'live' | 'paper' }` on the wire. This method
+   * accepts the canonical `mode` option, and also keeps backward compatibility
+   * for callers that still pass the legacy `paperMode` boolean (translated to
+   * `mode` before being sent). The legacy `deploymentMode` field has never been
+   * accepted by the platform and is silently dropped.
    */
   async startStrategy(
     id: string,
-    options: { paperMode?: boolean; deploymentMode?: 'LIVE' | 'SIMULATION' } = { paperMode: true },
+    options: {
+      /** Execution mode. Defaults to `'paper'` when omitted. */
+      mode?: 'live' | 'paper';
+      /** @deprecated Use `mode` instead. `true` maps to `'paper'`, `false` to `'live'`. */
+      paperMode?: boolean;
+      /** @deprecated Not accepted by the platform; ignored. */
+      deploymentMode?: 'LIVE' | 'SIMULATION';
+    } = {},
   ): Promise<StrategyStatusResponse> {
+    let mode: 'live' | 'paper';
+    if (options.mode !== undefined) {
+      mode = options.mode;
+    } else if (options.paperMode !== undefined) {
+      mode = options.paperMode ? 'paper' : 'live';
+    } else {
+      mode = 'paper';
+    }
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/start`, {
-      body: options,
+      body: { mode },
     });
   }
 


### PR DESCRIPTION
## Problem

`startStrategy` was sending `{ paperMode, deploymentMode }` on the wire, but the platform's `StartStrategyDto` requires `{ mode: 'live' | 'paper' }` (validated by `class-validator` `@IsIn(['live','paper'])`). The platform rejects every SDK-issued start with a 400. This is a regression of #179 — the previous compat fix in #159 (commit `3b74847`) flipped the SDK to a payload shape the platform never accepted.

Source of truth confirmed in three places:
- `services/api-service/src/strategies/dto/start-strategy.dto.ts` — `@IsIn(['live','paper']) mode`
- `apps/user-app/src/pages/api-docs/api-docs-endpoints.ts:147` — documented as `-d '{\"mode\":\"paper\"}'`
- The MCP and other SDKs already send `{ mode }`

## What changed

**`src/client.ts`** — `startStrategy` now translates at the SDK boundary:

- Accepts the canonical `{ mode: 'live' | 'paper' }` as the new public input.
- Keeps the legacy `paperMode: boolean` as a `@deprecated` input, translated to `mode` before dispatch (`paperMode: true → mode: 'paper'`, `paperMode: false → mode: 'live'`). This avoids breaking SDK 1.x consumers.
- Silently drops the legacy `deploymentMode` field — it was never accepted by the platform.
- Default remains paper mode (`{ mode: 'paper' }`) when no option is passed.
- When both `mode` and `paperMode` are provided, `mode` wins.

**`src/__tests__/client.test.ts`** — replaced 4 #145-era tests (which asserted the SDK output rather than the platform contract) with 7 tests covering the full translation matrix and explicit guards against `paperMode`/`deploymentMode` ever appearing on the wire.

**`CHANGELOG.md`** — Unreleased entry documenting the fix and deprecation.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/client.test.ts` — 9 files, 2589 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Manual verification: payload now matches platform DTO (`{ mode }`)

## Out of scope (follow-up note)

`pnpm test` (unscoped) reports 7 failures from vitest crawling sibling Paperclip worktree directories under `.paperclip/worktrees/*/dist/__tests__/client.test.js`. The `vitest.config.ts` exclude list covers `dist/**` and `node_modules/**` but not `.paperclip/worktrees/**`. These are local-only artifacts (untracked) and pre-existing on master — not introduced by this PR. Worth a one-line config bump in a separate change.

closes #190