### PR TITLE
fix(sdk): align MarketSlot with platform DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@
   Added regression coverage that asserts the serialized body uses
   `strategy.blocks.triggers` and does not send forbidden top-level block
   arrays. (closes #207)
+- **`MarketSlot` platform compatibility** — rewrote the SDK `MarketSlot`
+  interface from phantom `slotId`/`marketId`/`tokenId` fields to the platform
+  DTO shape: required `slot`, optional `label`, and optional
+  `defaultMarketId`. `createStrategy({ marketSlots })` now serializes fields
+  accepted by PolyForge API validation. (closes #204)
 - **`UpdateSettingsProfileParams` shape** — removed the phantom `username`
   field (the platform's `PATCH /api/v1/settings/profile` does not whitelist
   `username` and `forbidNonWhitelisted` rejects any payload containing it

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
-import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema } from '../types';
+import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, MarketSlot } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -1454,7 +1454,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
       variables: [{ name: 'threshold', type: 'number', defaultValue: '0.5' }],
       canvas: { zoom: 1, offsetX: 0, offsetY: 0 },
       marketId: 'mkt-1',
-      marketSlots: [{ slotId: 'slot-1', marketId: 'mkt-1', tokenId: 'tok-1' }],
+      marketSlots: [{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }],
     };
     await client.createStrategy(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
@@ -1469,6 +1469,21 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
     expect(body).toHaveProperty('variables');
     expect(body).toHaveProperty('canvas');
     expect(body).toHaveProperty('marketSlots');
+    expect(body.marketSlots).toEqual([{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }]);
+    expect(JSON.stringify(body)).not.toContain('slotId');
+    expect(JSON.stringify(body)).not.toContain('tokenId');
+  });
+
+  it('MarketSlot uses platform field names (#204)', () => {
+    const slot: MarketSlot = {
+      slot: 'leg1',
+      label: 'Leg 1',
+      defaultMarketId: 'mkt-1',
+    };
+
+    expect(JSON.stringify({ marketSlots: [slot] })).toBe(
+      '{"marketSlots":[{"slot":"leg1","label":"Leg 1","defaultMarketId":"mkt-1"}]}',
+    );
   });
 
   it('should still work with minimal params (backward compat)', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,9 +315,9 @@ export interface CreateStrategyParams {
 }
 
 export interface MarketSlot {
-  slotId: string;
-  marketId: string;
-  tokenId?: string;
+  slot: string;
+  label?: string;
+  defaultMarketId?: string;
 }
 
 export interface UpdateStrategyParams {


### PR DESCRIPTION
## Summary
- Replaces SDK MarketSlot fields with the platform DTO shape: slot, label, defaultMarketId
- Adds createStrategy serialization coverage to assert old slotId/tokenId fields are absent
- Adds an unreleased changelog note

## Verification
- RED: npm run typecheck failed before the type fix with 'slot' not existing on MarketSlot
- npm run typecheck
- npm test -- src/__tests__/client.test.ts
- npm test
- npm run build
- git diff --check
- GitNexus impact: MarketSlot/CreateStrategyParams risk LOW, 0 direct dependents, 0 affected flows/modules

Note: npx gitnexus detect_changes is not available in the installed GitNexus CLI (unknown command), so diff/status checks were used as fallback scope verification.

Closes #204