### PR TITLE
fix(security): avoid regex backtracking in base URL trim

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -62,7 +62,15 @@ describe('PolyforgeClient', () => {
         apiKey: 'test-key',
         apiUrl: 'http://localhost:3002///',
       });
-      expect(clientWithSlash).toBeDefined();
+      expect(clientWithSlash.toJSON()).toEqual({ baseUrl: 'http://localhost:3002' });
+    });
+
+    it('should normalize pathological trailing slash runs without regex backtracking', () => {
+      const client = new PolyforgeClient({
+        apiKey: 'test-key',
+        apiUrl: `https://api.example.com${'/'.repeat(50_000)}`,
+      });
+      expect(client.toJSON()).toEqual({ baseUrl: 'https://api.example.com' });
     });
 
     it('should handle URL paths correctly', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -192,6 +192,14 @@ function normalizePaginatedResponse<T>(
   };
 }
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 /**
  * Expand a compressed IPv6 address into its full 8-group colon-hex form.
  * E.g. "fe80::1" → "fe80:0000:0000:0000:0000:0000:0000:0001"
@@ -370,7 +378,7 @@ export class PolyforgeClient {
     if (!options.apiKey) {
       throw new Error('apiKey is required');
     }
-    this.baseUrl = (options.apiUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.baseUrl = trimTrailingSlashes(options.apiUrl ?? DEFAULT_BASE_URL);
     this.apiKey = options.apiKey;
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
     this.streamTimeout = options.streamTimeout ?? DEFAULT_STREAM_TIMEOUT_MS;


### PR DESCRIPTION
## Summary
- Replaces the trailing-slash regular expression used for `apiUrl` normalization with a linear scanner.
- Adds regression coverage for long trailing slash runs so base URL normalization stays safe.

## Verification
- `npm test -- --run src/__tests__/client.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Notes
- GitHub CodeQL alert: `js/polynomial-redos` at `src/client.ts:373` / code-scanning alert #1.
- Local CodeQL CLI is not installed in this worktree host, so final alert closure depends on the PR CodeQL scan.