### PR TITLE
fix: require idempotency keys for trading writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,16 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 | `placeBatchOrders(orders, idempotencyKey)` | Place multiple orders in one request |
 | `closePosition(params, idempotencyKey)` | Close an open position |
 | `redeemPosition(params, idempotencyKey)` | Redeem winning shares |
-| `splitPosition(params, idempotencyKey)` | Split a position |
-| `mergePosition(params, idempotencyKey)` | Merge positions |
+| `splitPosition(params)` | Split a position |
+| `mergePosition(params)` | Merge positions |
 | `cancelOrder(orderId)` | Cancel a pending or live order |
 
-Trading write methods that create or transform orders require a caller-generated
-`idempotencyKey` between 8 and 128 characters. Reuse the same key when retrying
-the same request, and generate a new key for a different trading action. This
-also applies to `createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`,
-`executeArb`, and `closeArbPosition`.
+Protected trading write methods require a caller-generated `idempotencyKey`
+between 8 and 128 characters. Reuse the same key when retrying the same request,
+and generate a new key for a different trading action. This applies to
+`placeOrder`, `placeBatchOrders`, `closePosition`, `redeemPosition`,
+`createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`, `executeArb`,
+and `closeArbPosition`.
 
 ### Social & Signals
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,19 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 | `getPortfolio()` | Get portfolio summary with positions |
 | `getOrders(params?)` | List orders with optional filters |
 | `getScore()` | Get your trader score and ranking |
-| `placeOrder(params)` | Place a direct buy/sell order |
+| `placeOrder(params, idempotencyKey)` | Place a direct buy/sell order |
+| `placeBatchOrders(orders, idempotencyKey)` | Place multiple orders in one request |
+| `closePosition(params, idempotencyKey)` | Close an open position |
+| `redeemPosition(params, idempotencyKey)` | Redeem winning shares |
+| `splitPosition(params, idempotencyKey)` | Split a position |
+| `mergePosition(params, idempotencyKey)` | Merge positions |
 | `cancelOrder(orderId)` | Cancel a pending or live order |
+
+Trading write methods that create or transform orders require a caller-generated
+`idempotencyKey` between 8 and 128 characters. Reuse the same key when retrying
+the same request, and generate a new key for a different trading action. This
+also applies to `createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`,
+`executeArb`, and `closeArbPosition`.
 
 ### Social & Signals
 
@@ -139,7 +150,7 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 |--------|-------------|
 | `getAccuracy()` | Brier score, win rate, calibration buckets, and per-category breakdown |
 | `getMarketSentiment(marketId)` | Sentiment score (−100 to +100) and BULLISH / BEARISH / NEUTRAL label |
-| `provideLiquidity(params)` | Post liquidity; returns `LpPosition` with buy and sell order IDs |
+| `provideLiquidity(params, idempotencyKey)` | Post liquidity; returns `LpPosition` with buy and sell order IDs |
 
 ## Error Handling
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2795,16 +2795,6 @@ describe('Trading write idempotency (#208)', () => {
       call: (key: string) => client.redeemPosition({ positionId: 'pos-1' }, key),
     },
     {
-      name: 'splitPosition',
-      path: '/api/v1/orders/split',
-      call: (key: string) => client.splitPosition({ tokenId: 'tok-1', amount: '10' }, key),
-    },
-    {
-      name: 'mergePosition',
-      path: '/api/v1/orders/merge',
-      call: (key: string) => client.mergePosition({ tokenId: 'tok-1', amount: '10' }, key),
-    },
-    {
       name: 'createConditionalOrder',
       path: '/api/v1/orders/conditional',
       call: (key: string) => client.createConditionalOrder({
@@ -2837,6 +2827,20 @@ describe('Trading write idempotency (#208)', () => {
         { marketId: 'mkt-1', tokenId: 'tok-1', amountUsdc: 100 },
         key,
       ),
+    },
+  ];
+  const unprotectedPositionWrites = [
+    {
+      name: 'splitPosition',
+      path: '/api/v1/orders/split',
+      params: { tokenId: 'tok-1', amount: '10' },
+      call: (params: SplitPositionParams) => client.splitPosition(params),
+    },
+    {
+      name: 'mergePosition',
+      path: '/api/v1/orders/merge',
+      params: { tokenId: 'tok-1', amount: '10' },
+      call: (params: MergePositionParams) => client.mergePosition(params),
     },
   ];
 
@@ -2874,6 +2878,29 @@ describe('Trading write idempotency (#208)', () => {
     for (const [, init] of fetchSpy.mock.calls) {
       expect((init!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
     }
+  });
+
+  it.each(unprotectedPositionWrites)('$name sends POST without Idempotency-Key until the API protects it', async ({ path, params, call }) => {
+    await call(params);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(new URL(fetchSpy.mock.calls[0][0] as string).pathname).toBe(path);
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
+  });
+
+  it.each(unprotectedPositionWrites)('$name forwards the position body without idempotency fields', async ({ params, call }) => {
+    await call(params);
+
+    expect(JSON.parse(fetchSpy.mock.calls[0][1]!.body as string)).toEqual(params);
+    expect(JSON.parse(fetchSpy.mock.calls[0][1]!.body as string)).not.toHaveProperty('idempotencyKey');
+  });
+
+  it.each(unprotectedPositionWrites)('$name ignores accidental extra key arguments instead of validating them', async ({ params, call }) => {
+    await (call as unknown as (requestParams: SplitPositionParams | MergePositionParams, key: string) => Promise<unknown>)(params, 'short');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
   });
 });
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -226,7 +226,7 @@ describe('Platform contract compliance', () => {
       totalSize: 100,
       slices: 5,
       intervalMinutes: 15,
-    });
+    }, 'smart-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('intervalMinutes', 15);
     expect(body).not.toHaveProperty('intervalSeconds');
@@ -711,11 +711,12 @@ describe('ProvideLiquidityParams uses marketId, not tokenId/spread (#25)', () =>
 
   it('sends { marketId, tokenId, amountUsdc } matching platform ProvideLiquidityDto', async () => {
     const params: ProvideLiquidityParams = { marketId: 'mkt-1', tokenId: 'tok-1', amountUsdc: 100 };
-    await client.provideLiquidity(params);
+    await client.provideLiquidity(params, 'liquidity-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toEqual({ marketId: 'mkt-1', tokenId: 'tok-1', amountUsdc: 100 });
     expect(body).not.toHaveProperty('size');
     expect(body).not.toHaveProperty('spread');
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBe('liquidity-key-123');
   });
 });
 
@@ -992,7 +993,7 @@ describe('CreateConditionalOrderParams matches platform DTO (#49)', () => {
       size: 50,
       triggerPrice: 0.3,
     };
-    await client.createConditionalOrder(params);
+    await client.createConditionalOrder(params, 'conditional-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('tokenId', 'tok-1');
     expect(body).toHaveProperty('type', 'STOP_LOSS');
@@ -1016,7 +1017,7 @@ describe('CreateConditionalOrderParams matches platform DTO (#49)', () => {
       trailingPct: '5.0',
       expiresAt: '2026-05-01T00:00:00Z',
     };
-    await client.createConditionalOrder(params);
+    await client.createConditionalOrder(params, 'conditional-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('limitPrice', '0.55');
     expect(body).toHaveProperty('trailingPct', '5.0');
@@ -2714,10 +2715,11 @@ describe('Orders — bulk operations (#156)', () => {
     const stub = { results: [{ orderId: 'o-1', intentId: 'i-1', status: 'PENDING' }] };
     fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(stub), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     const orders = [{ marketId: 'mkt-1', tokenId: 'tok-1', side: 'BUY' as const, outcome: 'YES' as const, size: 10, price: 0.5 }];
-    await client.placeBatchOrders(orders);
+    await client.placeBatchOrders(orders, 'batch-key-123');
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toBe('/api/v1/orders/batch');
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBe('batch-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('orders');
     expect(Array.isArray(body.orders)).toBe(true);
@@ -2727,10 +2729,11 @@ describe('Orders — bulk operations (#156)', () => {
   it('placeOrder sends POST to /api/v1/orders/place with marketId', async () => {
     const stub = { orderId: 'o-1', intentId: 'i-1', status: 'PENDING' };
     fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(stub), { status: 200, headers: { 'Content-Type': 'application/json' } }));
-    await client.placeOrder({ marketId: 'mkt-1', tokenId: 'tok-1', side: 'BUY', outcome: 'YES', size: 10, price: 0.5 });
+    await client.placeOrder({ marketId: 'mkt-1', tokenId: 'tok-1', side: 'BUY', outcome: 'YES', size: 10, price: 0.5 }, 'order-key-123');
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toBe('/api/v1/orders/place');
     expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBe('order-key-123');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body.marketId).toBe('mkt-1');
     expect(body.tokenId).toBe('tok-1');
@@ -2746,6 +2749,131 @@ describe('Orders — bulk operations (#156)', () => {
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toHaveProperty('orderIds');
     expect(body.orderIds).toEqual(['o-1', 'o-2']);
+  });
+});
+
+describe('Trading write idempotency (#208)', () => {
+  let client: PolyforgeClient;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = new PolyforgeClient({ apiKey: 'test-key', apiUrl: 'https://api.polyforge.app' });
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const tradingWrites = [
+    {
+      name: 'placeOrder',
+      path: '/api/v1/orders/place',
+      call: (key: string) => client.placeOrder(
+        { marketId: 'mkt-1', tokenId: 'tok-1', side: 'BUY', outcome: 'YES', size: 10, price: 0.5 },
+        key,
+      ),
+    },
+    {
+      name: 'placeBatchOrders',
+      path: '/api/v1/orders/batch',
+      call: (key: string) => client.placeBatchOrders(
+        [{ marketId: 'mkt-1', tokenId: 'tok-1', side: 'BUY', outcome: 'YES', size: 10, price: 0.5 }],
+        key,
+      ),
+    },
+    {
+      name: 'closePosition',
+      path: '/api/v1/orders/close-position',
+      call: (key: string) => client.closePosition({ tokenId: 'tok-1', size: '10' }, key),
+    },
+    {
+      name: 'redeemPosition',
+      path: '/api/v1/orders/redeem',
+      call: (key: string) => client.redeemPosition({ positionId: 'pos-1' }, key),
+    },
+    {
+      name: 'splitPosition',
+      path: '/api/v1/orders/split',
+      call: (key: string) => client.splitPosition({ tokenId: 'tok-1', amount: '10' }, key),
+    },
+    {
+      name: 'mergePosition',
+      path: '/api/v1/orders/merge',
+      call: (key: string) => client.mergePosition({ tokenId: 'tok-1', amount: '10' }, key),
+    },
+    {
+      name: 'createConditionalOrder',
+      path: '/api/v1/orders/conditional',
+      call: (key: string) => client.createConditionalOrder({
+        marketId: 'mkt-1',
+        tokenId: 'tok-1',
+        type: 'STOP_LOSS',
+        side: 'SELL',
+        outcome: 'YES',
+        size: 50,
+        triggerPrice: 0.3,
+      }, key),
+    },
+    {
+      name: 'placeSmartOrder',
+      path: '/api/v1/orders/smart',
+      call: (key: string) => client.placeSmartOrder({
+        type: 'TWAP',
+        tokenId: 'tok-1',
+        side: 'BUY',
+        outcome: 'YES',
+        totalSize: 100,
+        slices: 5,
+        intervalMinutes: 15,
+      }, key),
+    },
+    {
+      name: 'provideLiquidity',
+      path: '/api/v1/lp/provide',
+      call: (key: string) => client.provideLiquidity(
+        { marketId: 'mkt-1', tokenId: 'tok-1', amountUsdc: 100 },
+        key,
+      ),
+    },
+  ];
+
+  it.each(tradingWrites)('$name sends Idempotency-Key on the protected POST endpoint', async ({ path, call }) => {
+    await call('trade-key-123');
+
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe(path);
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
+    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBe('trade-key-123');
+  });
+
+  it.each(tradingWrites)('$name rejects a missing idempotencyKey before fetch', async ({ call }) => {
+    await expect(call(undefined as unknown as string)).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('idempotencyKey'),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(tradingWrites)('$name rejects an invalid idempotencyKey before fetch', async ({ call }) => {
+    await expect(call('short')).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: expect.stringContaining('idempotencyKey'),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps unprotected cancel endpoints free of Idempotency-Key', async () => {
+    await client.cancelOrder('order-1');
+    await client.cancelOrdersBulk(['order-1']);
+    await client.cancelConditionalOrder('conditional-1');
+    await client.cancelSmartOrder('smart-1');
+
+    for (const [, init] of fetchSpy.mock.calls) {
+      expect((init!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
+    }
   });
 });
 
@@ -3024,7 +3152,7 @@ describe('redeemPosition return type (#152)', () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify(redeemResponse), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
-    const result = await client.redeemPosition({ positionId: 'pos-1' });
+    const result = await client.redeemPosition({ positionId: 'pos-1' }, 'redeem-key-123');
     expect(result).toHaveProperty('positionId', 'pos-1');
     expect(result).toHaveProperty('intentId', 'int-1');
     expect(result).not.toHaveProperty('orderId');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1100,8 +1100,11 @@ export class PolyforgeClient {
   }
 
   /** Create a conditional order. */
-  async createConditionalOrder(params: CreateConditionalOrderParams): Promise<ConditionalOrder> {
-    return this.request('POST', '/api/v1/orders/conditional', { body: params });
+  async createConditionalOrder(params: CreateConditionalOrderParams, idempotencyKey: string): Promise<ConditionalOrder> {
+    return this.request('POST', '/api/v1/orders/conditional', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /** Get a single conditional order by ID. */
@@ -1456,11 +1459,17 @@ export class PolyforgeClient {
 
   /**
    * Place a direct buy or sell order on a prediction market.
+   *
+   * Pass a stable caller-generated `idempotencyKey` and reuse it when retrying
+   * the same order placement request.
    */
-  async placeOrder(params: PlaceOrderParams): Promise<PlaceOrderResponse> {
+  async placeOrder(params: PlaceOrderParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     this.validateFinancialParam('size', params.size);
     this.validateFinancialParam('price', params.price);
-    return this.request<PlaceOrderResponse>('POST', '/api/v1/orders/place', { body: params });
+    return this.request<PlaceOrderResponse>('POST', '/api/v1/orders/place', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
@@ -1473,8 +1482,11 @@ export class PolyforgeClient {
   /**
    * Place multiple orders in a single request (1–15 orders).
    */
-  async placeBatchOrders(orders: PlaceOrderParams[]): Promise<BatchPlaceOrdersResult> {
-    return this.request('POST', '/api/v1/orders/batch', { body: { orders } });
+  async placeBatchOrders(orders: PlaceOrderParams[], idempotencyKey: string): Promise<BatchPlaceOrdersResult> {
+    return this.request('POST', '/api/v1/orders/batch', {
+      body: { orders },
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
@@ -1487,29 +1499,41 @@ export class PolyforgeClient {
   /**
    * Close an open position (sell all shares at market price).
    */
-  async closePosition(params: ClosePositionParams): Promise<PlaceOrderResponse> {
-    return this.request('POST', '/api/v1/orders/close-position', { body: params });
+  async closePosition(params: ClosePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
+    return this.request('POST', '/api/v1/orders/close-position', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
    * Redeem winning shares after a market resolves.
    */
-  async redeemPosition(params: RedeemPositionParams): Promise<RedeemPositionResponse> {
-    return this.request<RedeemPositionResponse>('POST', '/api/v1/orders/redeem', { body: params });
+  async redeemPosition(params: RedeemPositionParams, idempotencyKey: string): Promise<RedeemPositionResponse> {
+    return this.request<RedeemPositionResponse>('POST', '/api/v1/orders/redeem', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
    * Split a position into smaller positions.
    */
-  async splitPosition(params: SplitPositionParams): Promise<PlaceOrderResponse> {
-    return this.request('POST', '/api/v1/orders/split', { body: params });
+  async splitPosition(params: SplitPositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
+    return this.request('POST', '/api/v1/orders/split', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
    * Merge multiple positions into one.
    */
-  async mergePosition(params: MergePositionParams): Promise<PlaceOrderResponse> {
-    return this.request('POST', '/api/v1/orders/merge', { body: params });
+  async mergePosition(params: MergePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
+    return this.request('POST', '/api/v1/orders/merge', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   // ── Arbitrage ────────────────────────────────────────────────────────────
@@ -1703,9 +1727,12 @@ export class PolyforgeClient {
   /**
    * Place an advanced smart order (TWAP, DCA, BRACKET, or OCO).
    */
-  async placeSmartOrder(params: PlaceSmartOrderParams): Promise<PlaceSmartOrderResponse> {
+  async placeSmartOrder(params: PlaceSmartOrderParams, idempotencyKey: string): Promise<PlaceSmartOrderResponse> {
     this.validateFinancialParam('totalSize', params.totalSize);
-    return this.request('POST', '/api/v1/orders/smart', { body: params });
+    return this.request('POST', '/api/v1/orders/smart', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   /**
@@ -1826,9 +1853,12 @@ export class PolyforgeClient {
   /**
    * Provide liquidity by placing two-sided quotes on a market token.
    */
-  async provideLiquidity(params: ProvideLiquidityParams): Promise<LpPosition> {
+  async provideLiquidity(params: ProvideLiquidityParams, idempotencyKey: string): Promise<LpPosition> {
     this.validateFinancialParam('amountUsdc', params.amountUsdc);
-    return this.request('POST', '/api/v1/lp/provide', { body: params });
+    return this.request('POST', '/api/v1/lp/provide', {
+      body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
+    });
   }
 
   // ── Rewards ─────────────────────────────────────────────────────────────

--- a/src/client.ts
+++ b/src/client.ts
@@ -1519,20 +1519,18 @@ export class PolyforgeClient {
   /**
    * Split a position into smaller positions.
    */
-  async splitPosition(params: SplitPositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
+  async splitPosition(params: SplitPositionParams): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/split', {
       body: params,
-      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 
   /**
    * Merge multiple positions into one.
    */
-  async mergePosition(params: MergePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
+  async mergePosition(params: MergePositionParams): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/merge', {
       body: params,
-      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 


### PR DESCRIPTION
## Summary
- require caller-supplied Idempotency-Key values for SDK trading POST writes protected by the API interceptor
- cover order place/batch, close/redeem/split/merge, conditional order, smart order, and liquidity provide while leaving cancel DELETE calls without the header
- document the idempotencyKey argument in the README

## Test Plan
- npm test
- npm run typecheck
- npm run build
- git diff --check

Closes #208