### PR TITLE
fix(sdk): align StrategyVariable shape with platform DTO (closes #226)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1461,7 +1461,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
       logicBlocks: [],
       calcBlocks: [],
       tags: ['alpha', 'crypto'],
-      variables: [{ name: 'threshold', type: 'number', defaultValue: '0.5' }],
+      variables: [{ id: 'v1', name: 'threshold', expression: 'price * 2' }],
       canvas: { zoom: 1, offsetX: 0, offsetY: 0 },
       marketId: 'mkt-1',
       marketSlots: [{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export type {
   ImportStrategyParams,
   LeaderboardParams,
   ImportStrategyPayload,
+  ImportStrategyVariable,
   Market,
   MarketSearchResult,
   MarketSlot,

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,10 +89,9 @@ export interface Strategy {
 }
 
 export interface StrategyVariable {
+  id: string;
   name: string;
-  type: 'number' | 'string' | 'boolean';
-  defaultValue?: string;
-  description?: string;
+  expression: string;
 }
 
 /** Response from strategy lifecycle operations (start/stop/pause/resume). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,11 @@ export interface StrategyVariable {
   expression: string;
 }
 
+export interface ImportStrategyVariable {
+  name: string;
+  expression: string;
+}
+
 /** Response from strategy lifecycle operations (start/stop/pause/resume). */
 export interface StrategyStatusResponse {
   status: StrategyStatus;
@@ -345,7 +350,7 @@ export interface ImportStrategyPayload {
   tickMs?: number;
   visibility?: StrategyVisibility;
   tags?: string[];
-  variables?: StrategyVariable[];
+  variables?: ImportStrategyVariable[];
   blocks?: ImportStrategyBlocks;
   canvas?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

- Changed `StrategyVariable` shape from `{name, type, defaultValue?, description?}` to `{id, name, expression}` to match platform `StrategyVariableDto`
- Added `ImportStrategyVariable` type `{name, expression}` for import payloads, matching platform `ImportVariableDto` (no `id` required)
- Updated `ImportStrategyPayload.variables` to use `ImportStrategyVariable[]`
- Updated test data accordingly

## Verification
- Typecheck: passes (0 errors)
- Tests: 435 passed (0 failures)