### PR TITLE
fix(sdk): replace HARMFUL with INAPPROPRIATE in StrategyReportReason (#225)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2137,11 +2137,11 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(body).toEqual({ reason: 'MISLEADING' });
   });
 
-  it('reportStrategy maps HARMFUL to INAPPROPRIATE for platform compat', async () => {
+  it('reportStrategy sends INAPPROPRIATE directly', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ reportId: 'r-3' }), { status: 201, headers: { 'Content-Type': 'application/json' } }),
     );
-    await client.reportStrategy('s-1', 'HARMFUL');
+    await client.reportStrategy('s-1', 'INAPPROPRIATE');
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toEqual({ reason: 'INAPPROPRIATE' });
   });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2137,6 +2137,15 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(body).toEqual({ reason: 'MISLEADING' });
   });
 
+  it('reportStrategy maps HARMFUL to INAPPROPRIATE for platform compat', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ reportId: 'r-3' }), { status: 201, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await client.reportStrategy('s-1', 'HARMFUL');
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({ reason: 'INAPPROPRIATE' });
+  });
+
   it('listStrategyVersions sends GET /api/v1/strategies/:id/versions', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify([{ id: 'v-1', version: 1 }]), { status: 200, headers: { 'Content-Type': 'application/json' } }),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1029,9 +1029,8 @@ export class PolyforgeClient {
    * Report a strategy for violating guidelines.
    */
   async reportStrategy(id: string, reason: StrategyReportReason, description?: string): Promise<StrategyReportResult> {
-    const normalizedReason = reason === 'HARMFUL' ? 'INAPPROPRIATE' : reason;
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/report`, {
-      body: { reason: normalizedReason, ...(description !== undefined && { description }) },
+      body: { reason, ...(description !== undefined && { description }) },
     });
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1029,8 +1029,9 @@ export class PolyforgeClient {
    * Report a strategy for violating guidelines.
    */
   async reportStrategy(id: string, reason: StrategyReportReason, description?: string): Promise<StrategyReportResult> {
+    const normalizedReason = reason === 'HARMFUL' ? 'INAPPROPRIATE' : reason;
     return this.request('POST', `/api/v1/strategies/${encodeURIComponent(id)}/report`, {
-      body: { reason, ...(description !== undefined && { description }) },
+      body: { reason: normalizedReason, ...(description !== undefined && { description }) },
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -620,7 +620,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
+export type StrategyReportReason = 'SPAM' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -620,7 +620,7 @@ export interface LpPosition {
 
 // ── Strategy Social ────────────────────────────────────────────────────────
 
-export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'MISLEADING' | 'OTHER';
+export type StrategyReportReason = 'SPAM' | 'HARMFUL' | 'INAPPROPRIATE' | 'MISLEADING' | 'OTHER';
 
 export interface StrategyLikeResult {
   liked: boolean;


### PR DESCRIPTION
## Summary

Fixes a compatibility regression where the SDK's `StrategyReportReason` type used `'HARMFUL'` which is rejected by the platform API. The platform validates against `['SPAM', 'MISLEADING', 'INAPPROPRIATE', 'OTHER']`.

## Changes

- **`src/types.ts:619`** — Replaced `'HARMFUL'` with `'INAPPROPRIATE'` in the `StrategyReportReason` union type
- **`src/client.ts:1031`** — Removed the HARMFUL→INAPPROPRIATE runtime normalization shim; `reason` is now forwarded verbatim
- **`src/__tests__/client.test.ts:2140`** — Added test for direct `'INAPPROPRIATE'` reason

## Verification

- `tsc --noEmit`: clean (0 errors)
- `vitest run`: 436 passed, 0 failed
- No remaining `'HARMFUL'` references in `src/`

Closes #225