### PR TITLE
docs(sdk-ts): clarify getAccuracyLeaderboard platform routing in JSDoc

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1232,9 +1232,13 @@ export class PolyforgeClient {
   }
 
   /**
-   * Get the accuracy/leaderboard view.
+   * Get the prediction accuracy leaderboard. This targets the platform
+   * leaderboard endpoint which returns accuracy-ranked rows (rank, userId,
+   * profile fields, pnl, winRate, tradeCount) — distinct from the P&L-only
+   * leaderboard and the authenticated-user accuracy score at `/api/v1/accuracy`.
+   * The companion `getAccuracy()` returns only the authenticated user's stats.
    *
-   * The API currently paginates this endpoint with `page` / `limit`; `offset`
+   * The API paginates this endpoint with `page` / `limit`; `offset`
    * is converted to the corresponding page when supplied.
    */
   async getAccuracyLeaderboard(

--- a/src/client.ts
+++ b/src/client.ts
@@ -1232,11 +1232,15 @@ export class PolyforgeClient {
   }
 
   /**
-   * Get the prediction accuracy leaderboard. This targets the platform
-   * leaderboard endpoint which returns accuracy-ranked rows (rank, userId,
-   * profile fields, pnl, winRate, tradeCount) — distinct from the P&L-only
-   * leaderboard and the authenticated-user accuracy score at `/api/v1/accuracy`.
-   * The companion `getAccuracy()` returns only the authenticated user's stats.
+   * Get the platform leaderboard augmented with win-rate and trade-count
+   * fields. Rows are ranked by P&L and include profile metadata (rank,
+   * userId, username, displayName, avatarUrl, pnl, winRate, tradeCount).
+   *
+   * This hits the same endpoint as {@link getLeaderboard} (`GET /api/v1/leaderboard`),
+   * but returns the richer {@link AccuracyLeaderboardEntry} shape with win-rate
+   * and trade-count fields. It is distinct from the authenticated-user accuracy
+   * score returned by `GET /api/v1/accuracy` (see {@link getAccuracy} and
+   * {@link getAccuracyOverview}).
    *
    * The API paginates this endpoint with `page` / `limit`; `offset`
    * is converted to the corresponding page when supplied.


### PR DESCRIPTION
## Summary
- Improves `getAccuracyLeaderboard()` JSDoc to accurately describe the platform routing
- Clarifies that the endpoint (`/api/v1/leaderboard`) returns P&L-ranked leaderboard rows augmented with win-rate and trade-count fields
- Documents the distinction from the authenticated-user accuracy endpoints (`/api/v1/accuracy`, `/api/v1/accuracy/me`)
- Adds `{@link}` references to `getLeaderboard`, `getAccuracy`, and `getAccuracyOverview` for discoverability
- No endpoint path change: `getAccuracyLeaderboard()` already correctly used `/api/v1/leaderboard`

### Verification
- All 436 tests pass, typecheck clean
- Platform contract: `GET /api/v1/leaderboard` via `DiscoverController` returns `PaginatedResponse<AccuracyLeaderboardEntry>` matching this SDK method's return type
- Platform `GET /api/v1/accuracy` returns authenticated-user personal accuracy score (`AccuracyService.getMyAccuracy`), not a paginated leaderboard

Related: [POLA-4271](https://github.com/F4CTE/polyforge-sdk-ts/issues?q=POLA-4271)