### PR TITLE
fix(sdk): route getAccuracyLeaderboard to /api/v1/accuracy/leaderboard instead of P&L leaderboard (closes #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Changed
+- **POLA-4423 endpoint fix** — `getAccuracyLeaderboard()` now routes to
+  `GET /api/v1/accuracy/leaderboard` (dedicated accuracy leaderboard) instead
+  of `GET /api/v1/leaderboard` (P&L-ranked leaderboard). Test assertion
+  updated to match. (closes #239)
 - **POLA-3691 compatibility audit** — re-verified all 21 endpoint paths
   from GitHub issue #220 against platform NestJS controllers. All paths,
   methods, and controller prefixes already match the platform. No code

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2414,7 +2414,7 @@ describe('Discover and Leaderboard (#66)', () => {
     expect(url.searchParams.get('period')).toBe('7d');
   });
 
-  it('getAccuracyLeaderboard sends paginated params to /api/v1/leaderboard', async () => {
+  it('getAccuracyLeaderboard sends paginated params to /api/v1/accuracy/leaderboard', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -2444,7 +2444,7 @@ describe('Discover and Leaderboard (#66)', () => {
     const result = await client.getAccuracyLeaderboard(params);
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
 
-    expect(url.pathname).toBe('/api/v1/leaderboard');
+    expect(url.pathname).toBe('/api/v1/accuracy/leaderboard');
     expect(url.searchParams.get('period')).toBe('30d');
     expect(url.searchParams.get('limit')).toBe('25');
     expect(url.searchParams.get('page')).toBe('3');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1232,14 +1232,15 @@ export class PolyforgeClient {
   }
 
   /**
-   * Get the platform leaderboard augmented with win-rate and trade-count
-   * fields. Rows are ranked by P&L and include profile metadata (rank,
-   * userId, username, displayName, avatarUrl, pnl, winRate, tradeCount).
+   * Get the accuracy leaderboard ranked by win-rate, augmented with trade-count
+   * and P&L fields. Rows include profile metadata (rank, userId, username,
+   * displayName, avatarUrl, pnl, winRate, tradeCount).
    *
-   * This hits the same endpoint as {@link getLeaderboard} (`GET /api/v1/leaderboard`),
-   * but returns the richer {@link AccuracyLeaderboardEntry} shape with win-rate
-   * and trade-count fields. It is distinct from the authenticated-user accuracy
-   * score returned by `GET /api/v1/accuracy` (see {@link getAccuracy} and
+   * This hits `GET /api/v1/accuracy/leaderboard` and returns the
+   * {@link AccuracyLeaderboardEntry} shape. It is distinct from
+   * {@link getLeaderboard} (`GET /api/v1/leaderboard`, ranked by P&L only)
+   * and from the authenticated-user accuracy score returned by
+   * `GET /api/v1/accuracy` (see {@link getAccuracy} and
    * {@link getAccuracyOverview}).
    *
    * The API paginates this endpoint with `page` / `limit`; `offset`

--- a/src/client.ts
+++ b/src/client.ts
@@ -1232,9 +1232,17 @@ export class PolyforgeClient {
   }
 
   /**
-   * Get the accuracy/leaderboard view.
+   * Get the platform leaderboard augmented with win-rate and trade-count
+   * fields. Rows are ranked by P&L and include profile metadata (rank,
+   * userId, username, displayName, avatarUrl, pnl, winRate, tradeCount).
    *
-   * The API currently paginates this endpoint with `page` / `limit`; `offset`
+   * This hits the same endpoint as {@link getLeaderboard} (`GET /api/v1/leaderboard`),
+   * but returns the richer {@link AccuracyLeaderboardEntry} shape with win-rate
+   * and trade-count fields. It is distinct from the authenticated-user accuracy
+   * score returned by `GET /api/v1/accuracy` (see {@link getAccuracy} and
+   * {@link getAccuracyOverview}).
+   *
+   * The API paginates this endpoint with `page` / `limit`; `offset`
    * is converted to the corresponding page when supplied.
    */
   async getAccuracyLeaderboard(

--- a/src/client.ts
+++ b/src/client.ts
@@ -1251,7 +1251,7 @@ export class PolyforgeClient {
       query.page = params.page;
     }
 
-    return this.request('GET', '/api/v1/leaderboard', { query });
+    return this.request('GET', '/api/v1/accuracy/leaderboard', { query });
   }
 
   // ── Paper trading ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Changes `getAccuracyLeaderboard()` endpoint from `GET /api/v1/leaderboard` (P&L-ranked) to `GET /api/v1/accuracy/leaderboard` (dedicated accuracy leaderboard)
- Updates test assertion to match the new endpoint path
- Supersedes PR #241 (which only updated JSDoc without fixing the route)

## Verification
- All 436 tests pass
- TypeScript typecheck clean
- No other endpoints affected

Related: POLA-4423, issue #239