### PR TITLE
fix(sdk): add kalshiSubaccount to CreateStrategyParams and UpdateStrategyParams (closes #240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   on non-UUID).
 
 ### Added
+- **Kalshi subaccount on strategies (#240)** — `kalshiSubaccount?: number`
+  field added to `Strategy`, `CreateStrategyParams`, and `UpdateStrategyParams`.
+  Maps to the Kalshi subaccount ID (0–99) stored as `Int? @db.SmallInt` on the
+  platform's `Strategy` model. Pass it to `createStrategy()` or
+  `updateStrategy()` and read it from `getStrategy()` / `listStrategies()`
+  responses. (closes #240)
 - **GDPR personal data export** — `exportPersonalData(format?)` for
   `GET /api/v1/me/export`. Returns a parsed `PersonalDataExport` object by
   default (JSON) or a raw CSV string when `format: 'csv'` is passed. The

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1401,7 +1401,7 @@ describe('SplitPositionParams and MergePositionParams match platform (#24)', () 
 });
 
 describe('Strategy uses categorized block arrays (#31)', () => {
-  it('should have triggers/conditions/actions/safety/logicBlocks/calcBlocks instead of flat blocks', () => {
+    it('should have triggers/conditions/actions/safety/logicBlocks/calcBlocks instead of flat blocks', () => {
     const strat: Strategy = {
       id: 's-1',
       name: 'Test Strategy',
@@ -1417,6 +1417,7 @@ describe('Strategy uses categorized block arrays (#31)', () => {
       calcBlocks: [],
       tags: ['test'],
       variables: [],
+      kalshiSubaccount: 3,
       pnl: 0,
       tradeCount: 0,
       winRate: 0,
@@ -1429,6 +1430,34 @@ describe('Strategy uses categorized block arrays (#31)', () => {
     expect(strat.safety).toHaveLength(0);
     // Old flat blocks field must not exist
     expect((strat as any).blocks).toBeUndefined();
+  });
+
+  it('should accept kalshiSubaccount on Strategy response type (#240)', () => {
+    const strat: Strategy = {
+      id: 's-1',
+      name: 'Test',
+      status: 'IDLE',
+      visibility: 'PRIVATE',
+      execMode: 'TICK',
+      tickMs: 1000,
+      triggers: [],
+      conditions: [],
+      actions: [],
+      safety: [],
+      logicBlocks: [],
+      calcBlocks: [],
+      tags: [],
+      variables: [],
+      kalshiSubaccount: 5,
+      pnl: 0,
+      tradeCount: 0,
+      winRate: 0,
+      createdAt: '',
+      updatedAt: '',
+    };
+    expect(strat.kalshiSubaccount).toBe(5);
+    const json = JSON.parse(JSON.stringify(strat));
+    expect(json).toHaveProperty('kalshiSubaccount', 5);
   });
 });
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1465,6 +1465,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
       canvas: { zoom: 1, offsetX: 0, offsetY: 0 },
       marketId: 'mkt-1',
       marketSlots: [{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }],
+      kalshiSubaccount: 42,
     };
     await client.createStrategy(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
@@ -1480,6 +1481,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
     expect(body).toHaveProperty('canvas');
     expect(body).toHaveProperty('marketSlots');
     expect(body.marketSlots).toEqual([{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }]);
+    expect(body).toHaveProperty('kalshiSubaccount', 42);
     expect(JSON.stringify(body)).not.toContain('slotId');
     expect(JSON.stringify(body)).not.toContain('tokenId');
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -316,6 +316,7 @@ export interface CreateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
+  kalshiSubaccount?: number;
 }
 
 export interface MarketSlot {
@@ -341,6 +342,7 @@ export interface UpdateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
+  kalshiSubaccount?: number;
 }
 
 export interface ImportStrategyPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface Strategy {
   variables: StrategyVariable[];
   canvas?: Record<string, unknown>;
   marketId?: string;
+  kalshiSubaccount?: number;
   pnl: number;
   tradeCount: number;
   winRate: number;


### PR DESCRIPTION
## Summary

The PolyForge platform's `CreateStrategyDto` accepts `kalshiSubaccount?: number (0-99)`, but the TypeScript SDK was missing this field in both `CreateStrategyParams` and `UpdateStrategyParams`. This PR adds `kalshiSubaccount?: number` to both interfaces.

## Changes

- **`src/types.ts`**: Added `kalshiSubaccount?: number` to `CreateStrategyParams` and `UpdateStrategyParams`
- **`src/__tests__/client.test.ts`**: Added test coverage for the new field

## Verification

- Tests: 436/436 passing
- Typecheck (tsc --noEmit): 0 errors