### PR TITLE
fix(sdk): add Idempotency-Key header to splitPosition and mergePosition (closes #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 | `placeBatchOrders(orders, idempotencyKey)` | Place multiple orders in one request |
 | `closePosition(params, idempotencyKey)` | Close an open position |
 | `redeemPosition(params, idempotencyKey)` | Redeem winning shares |
-| `splitPosition(params)` | Split a position |
-| `mergePosition(params)` | Merge positions |
+| `splitPosition(params, idempotencyKey)` | Split a position |
+| `mergePosition(params, idempotencyKey)` | Merge positions |
 | `cancelOrder(orderId)` | Cancel a pending or live order |
 
 Protected trading write methods require a caller-generated `idempotencyKey`
 between 8 and 128 characters. Reuse the same key when retrying the same request,
 and generate a new key for a different trading action. This applies to
 `placeOrder`, `placeBatchOrders`, `closePosition`, `redeemPosition`,
-`createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`, `executeArb`,
-and `closeArbPosition`.
+`splitPosition`, `mergePosition`, `createConditionalOrder`, `placeSmartOrder`,
+`provideLiquidity`, `executeArb`, and `closeArbPosition`.
 
 ### Social & Signals
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2882,19 +2882,15 @@ describe('Trading write idempotency (#208)', () => {
         key,
       ),
     },
-  ];
-  const unprotectedPositionWrites = [
     {
       name: 'splitPosition',
       path: '/api/v1/orders/split',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: SplitPositionParams) => client.splitPosition(params),
+      call: (key: string) => client.splitPosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
     {
       name: 'mergePosition',
       path: '/api/v1/orders/merge',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: MergePositionParams) => client.mergePosition(params),
+      call: (key: string) => client.mergePosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
   ];
 
@@ -2934,28 +2930,7 @@ describe('Trading write idempotency (#208)', () => {
     }
   });
 
-  it.each(unprotectedPositionWrites)('$name sends POST without Idempotency-Key until the API protects it', async ({ path, params, call }) => {
-    await call(params);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(new URL(fetchSpy.mock.calls[0][0] as string).pathname).toBe(path);
-    expect(fetchSpy.mock.calls[0][1]!.method).toBe('POST');
-    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
-  });
-
-  it.each(unprotectedPositionWrites)('$name forwards the position body without idempotency fields', async ({ params, call }) => {
-    await call(params);
-
-    expect(JSON.parse(fetchSpy.mock.calls[0][1]!.body as string)).toEqual(params);
-    expect(JSON.parse(fetchSpy.mock.calls[0][1]!.body as string)).not.toHaveProperty('idempotencyKey');
-  });
-
-  it.each(unprotectedPositionWrites)('$name ignores accidental extra key arguments instead of validating them', async ({ params, call }) => {
-    await (call as unknown as (requestParams: SplitPositionParams | MergePositionParams, key: string) => Promise<unknown>)(params, 'short');
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();
-  });
 });
 
 describe('News — articles (#156)', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1528,18 +1528,20 @@ export class PolyforgeClient {
   /**
    * Split a position into smaller positions.
    */
-  async splitPosition(params: SplitPositionParams): Promise<PlaceOrderResponse> {
+  async splitPosition(params: SplitPositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/split', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 
   /**
    * Merge multiple positions into one.
    */
-  async mergePosition(params: MergePositionParams): Promise<PlaceOrderResponse> {
+  async mergePosition(params: MergePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/merge', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 


### PR DESCRIPTION
## Summary
- Promote `splitPosition` and `mergePosition` to protected trading writes — both now require a caller-generated `idempotencyKey` (8–128 chars) and pass it through the shared `idempotencyHeaders()` validator
- Move split/merge tests from `unprotectedPositionWrites` into `tradingWrites` to participate in full idempotency parameterized tests
- Update README to include `splitPosition`/`mergePosition` in protected methods list

## Context
Regression fix of #208. The idempotency contract was originally established there, but `splitPosition`/`mergePosition` were missed.

## Verification
- `tsc --noEmit`: passes (0 errors)
- `vitest run`: 436 tests pass (0 failures)