### PR TITLE
fix(sdk): add Idempotency-Key header to splitPosition and mergePosition (closes #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,15 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 | `placeBatchOrders(orders, idempotencyKey)` | Place multiple orders in one request |
 | `closePosition(params, idempotencyKey)` | Close an open position |
 | `redeemPosition(params, idempotencyKey)` | Redeem winning shares |
-| `splitPosition(params)` | Split a position |
-| `mergePosition(params)` | Merge positions |
+| `splitPosition(params, idempotencyKey)` | Split a position |
+| `mergePosition(params, idempotencyKey)` | Merge positions |
 | `cancelOrder(orderId)` | Cancel a pending or live order |
 
 Protected trading write methods require a caller-generated `idempotencyKey`
 between 8 and 128 characters. Reuse the same key when retrying the same request,
 and generate a new key for a different trading action. This applies to
 `placeOrder`, `placeBatchOrders`, `closePosition`, `redeemPosition`,
+`splitPosition`, `mergePosition`,
 `createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`, `executeArb`,
 and `closeArbPosition`.
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2882,21 +2882,23 @@ describe('Trading write idempotency (#208)', () => {
         key,
       ),
     },
-  ];
-  const unprotectedPositionWrites = [
     {
       name: 'splitPosition',
       path: '/api/v1/orders/split',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: SplitPositionParams) => client.splitPosition(params),
+      call: (key: string) => client.splitPosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
     {
       name: 'mergePosition',
       path: '/api/v1/orders/merge',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: MergePositionParams) => client.mergePosition(params),
+      call: (key: string) => client.mergePosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
   ];
+  const unprotectedPositionWrites: Array<{
+    name: string;
+    path: string;
+    params: SplitPositionParams | MergePositionParams;
+    call: (params: SplitPositionParams | MergePositionParams) => Promise<unknown>;
+  }> = [];
 
   it.each(tradingWrites)('$name sends Idempotency-Key on the protected POST endpoint', async ({ path, call }) => {
     await call('trade-key-123');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1527,19 +1527,27 @@ export class PolyforgeClient {
 
   /**
    * Split a position into smaller positions.
+   *
+   * Pass a stable caller-generated `idempotencyKey` and reuse it when retrying
+   * the same split request.
    */
-  async splitPosition(params: SplitPositionParams): Promise<PlaceOrderResponse> {
+  async splitPosition(params: SplitPositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/split', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 
   /**
    * Merge multiple positions into one.
+   *
+   * Pass a stable caller-generated `idempotencyKey` and reuse it when retrying
+   * the same merge request.
    */
-  async mergePosition(params: MergePositionParams): Promise<PlaceOrderResponse> {
+  async mergePosition(params: MergePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/merge', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 


### PR DESCRIPTION
## Summary
- Promote `splitPosition` and `mergePosition` from unprotected to protected trading writes
- Both methods now require a caller-generated `idempotencyKey` (8-128 chars) and pass it through the shared `idempotencyHeaders()` validator
- Updated README to document the new signatures and include them in the protected methods list

## Changes
- **`src/client.ts`**: Added `idempotencyKey: string` parameter and `headers: this.idempotencyHeaders(idempotencyKey)` to both `splitPosition` and `mergePosition`
- **`src/__tests__/client.test.ts`**: Moved `splitPosition` and `mergePosition` from `unprotectedPositionWrites` to `tradingWrites` array, matching the idempotency contract of all other protected trading writes
- **`README.md`**: Updated method signatures and protected methods list

## Verification
- All 436 tests pass
- TypeScript typecheck (`tsc --noEmit`) passes cleanly

## Related
- Regression of #208 — the idempotency contract was originally added for trading writes but these two methods were missed