### PR TITLE
fix(sdk): restrict updateProfileNotifications to known notification keys (#237)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3567,12 +3567,12 @@ describe('Profile endpoints (POLA-780)', () => {
 
   it('updateProfileNotifications sends PATCH /api/v1/profile/notifications', async () => {
     fetchSpy.mockResolvedValueOnce(new Response(null, { status: 204 }));
-    await client.updateProfileNotifications({ emailOnOrderFilled: true });
+    await client.updateProfileNotifications({ onOrderFilled: true });
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(new URL(url).pathname).toBe('/api/v1/profile/notifications');
     expect(init.method).toBe('PATCH');
     const body = JSON.parse(init.body as string);
-    expect(body.emailOnOrderFilled).toBe(true);
+    expect(body.onOrderFilled).toBe(true);
   });
 
   it('getPublicProfile calls GET /api/v1/profile/:username', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -134,6 +134,8 @@ import type {
   UpdateSettingsProfileParams,
   NotificationSettings,
   UpdateNotificationSettingsParams,
+  ProfileNotificationPreferences,
+  UpdateProfileNotificationsParams,
   UpdateUserPreferencesParams,
   ChangePasswordSettingsParams,
   BetaUsage,
@@ -1958,7 +1960,7 @@ export class PolyforgeClient {
   }
 
   /** Update the authenticated user's notification preferences (profile-level). */
-  async updateProfileNotifications(preferences: Record<string, boolean>): Promise<void> {
+  async updateProfileNotifications(preferences: UpdateProfileNotificationsParams): Promise<void> {
     return this.request('PATCH', '/api/v1/profile/notifications', { body: preferences });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,8 @@ export type {
   UpdateSettingsProfileParams,
   NotificationSettings,
   UpdateNotificationSettingsParams,
+  ProfileNotificationPreferences,
+  UpdateProfileNotificationsParams,
   UpdateUserPreferencesParams,
   ChangePasswordSettingsParams,
   BetaUsage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1531,6 +1531,35 @@ export interface NotificationSettings {
 
 export type UpdateNotificationSettingsParams = Partial<NotificationSettings>;
 
+/**
+ * Notification preferences for `PATCH /api/v1/profile/notifications`.
+ *
+ * Mirrors the platform `UpdateProfileNotificationsDto`
+ * (`services/api-service/src/profile/dto/update-profile-notifications.dto.ts`):
+ * three channel toggles (`emailEnabled`, `telegramEnabled`, `discordEnabled`)
+ * plus per-event toggles and `onTicketReply`. The platform uses
+ * `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true })` and
+ * rejects unknown fields with HTTP 400 — keep this type in sync with the
+ * platform DTO. (closes #237)
+ */
+export interface ProfileNotificationPreferences {
+  emailEnabled?: boolean;
+  telegramEnabled?: boolean;
+  discordEnabled?: boolean;
+  onOrderFilled?: boolean;
+  onStrategyError?: boolean;
+  onBacktestComplete?: boolean;
+  onDailyLossLimit?: boolean;
+  onMarketResolved?: boolean;
+  onSomeoneForked?: boolean;
+  onSomeoneFollowed?: boolean;
+  onSomeoneLiked?: boolean;
+  onSomeoneCommented?: boolean;
+  onTicketReply?: boolean;
+}
+
+export type UpdateProfileNotificationsParams = Partial<ProfileNotificationPreferences>;
+
 export interface ChangePasswordSettingsParams {
   currentPassword: string;
   newPassword: string;


### PR DESCRIPTION
## Summary

- Replaces `Record<string, boolean>` with `ProfileNotificationPreferences` interface (13 fields)
- Cross-verified against platform `UpdateProfileNotificationsDto`
- Platform rejects unknown fields via `whitelist + forbidNonWhitelisted`

## Verification

- TypeScript: 0 errors
- Tests: 436/436 passing
- Fields match platform DTO at `services/api-service/src/profile/dto/update-profile-notifications.dto.ts`

Closes #237