### PR TITLE
fix(sdk): route getAccuracyLeaderboard to /api/v1/accuracy/leaderboard

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2414,7 +2414,7 @@ describe('Discover and Leaderboard (#66)', () => {
     expect(url.searchParams.get('period')).toBe('7d');
   });
 
-  it('getAccuracyLeaderboard sends paginated params to /api/v1/leaderboard', async () => {
+  it('getAccuracyLeaderboard sends paginated params to /api/v1/accuracy/leaderboard', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -2444,7 +2444,7 @@ describe('Discover and Leaderboard (#66)', () => {
     const result = await client.getAccuracyLeaderboard(params);
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
 
-    expect(url.pathname).toBe('/api/v1/leaderboard');
+    expect(url.pathname).toBe('/api/v1/accuracy/leaderboard');
     expect(url.searchParams.get('period')).toBe('30d');
     expect(url.searchParams.get('limit')).toBe('25');
     expect(url.searchParams.get('page')).toBe('3');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1251,7 +1251,7 @@ export class PolyforgeClient {
       query.page = params.page;
     }
 
-    return this.request('GET', '/api/v1/leaderboard', { query });
+    return this.request('GET', '/api/v1/accuracy/leaderboard', { query });
   }
 
   // ── Paper trading ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `getAccuracyLeaderboard()` was incorrectly hitting the generic P&L leaderboard endpoint `/api/v1/leaderboard` instead of the accuracy-scoped endpoint `/api/v1/accuracy/leaderboard`
- This caused the accuracy leaderboard to return P&L-based rankings instead of accuracy-based rankings

## Changes

- `src/client.ts`: Changed `getAccuracyLeaderboard()` target from `/api/v1/leaderboard` to `/api/v1/accuracy/leaderboard`
- `src/__tests__/client.test.ts`: Updated test assertion and description to match the corrected endpoint

## Verification

- Typecheck passes
- All 436 tests pass

Closes #239