### PR TITLE
fix(sdk-ts): add kalshiSubaccount to CreateStrategyParams and UpdateStrategyParams (closes #240)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1549,6 +1549,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
       canvas: { zoom: 1, offsetX: 0, offsetY: 0 },
       marketId: 'mkt-1',
       marketSlots: [{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }],
+      kalshiSubaccount: 'sub-123',
     };
     await client.createStrategy(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
@@ -1564,6 +1565,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
     expect(body).toHaveProperty('canvas');
     expect(body).toHaveProperty('marketSlots');
     expect(body.marketSlots).toEqual([{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }]);
+    expect(body).toHaveProperty('kalshiSubaccount', 'sub-123');
     expect(JSON.stringify(body)).not.toContain('slotId');
     expect(JSON.stringify(body)).not.toContain('tokenId');
   });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1549,7 +1549,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
       canvas: { zoom: 1, offsetX: 0, offsetY: 0 },
       marketId: 'mkt-1',
       marketSlots: [{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }],
-      kalshiSubaccount: 'sub-123',
+      kalshiSubaccount: 3,
     };
     await client.createStrategy(params);
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
@@ -1565,7 +1565,7 @@ describe('CreateStrategyParams includes all platform fields (#32)', () => {
     expect(body).toHaveProperty('canvas');
     expect(body).toHaveProperty('marketSlots');
     expect(body.marketSlots).toEqual([{ slot: 'slot-1', label: 'Primary market', defaultMarketId: 'mkt-1' }]);
-    expect(body).toHaveProperty('kalshiSubaccount', 'sub-123');
+    expect(body).toHaveProperty('kalshiSubaccount', 3);
     expect(JSON.stringify(body)).not.toContain('slotId');
     expect(JSON.stringify(body)).not.toContain('tokenId');
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,8 @@ export interface Strategy {
   variables: StrategyVariable[];
   canvas?: Record<string, unknown>;
   marketId?: string;
+  marketSlots?: MarketSlot[];
+  kalshiSubaccount?: string;
   pnl: number;
   tradeCount: number;
   winRate: number;
@@ -316,6 +318,7 @@ export interface CreateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
+  kalshiSubaccount?: string;
 }
 
 export interface MarketSlot {
@@ -341,6 +344,7 @@ export interface UpdateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
+  kalshiSubaccount?: string;
 }
 
 export interface ImportStrategyPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export interface Strategy {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
-  kalshiSubaccount?: string;
+  kalshiSubaccount?: number;
   pnl: number;
   tradeCount: number;
   winRate: number;
@@ -318,7 +318,7 @@ export interface CreateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
-  kalshiSubaccount?: string;
+  kalshiSubaccount?: number;
 }
 
 export interface MarketSlot {
@@ -344,7 +344,7 @@ export interface UpdateStrategyParams {
   canvas?: Record<string, unknown>;
   marketId?: string;
   marketSlots?: MarketSlot[];
-  kalshiSubaccount?: string;
+  kalshiSubaccount?: number;
 }
 
 export interface ImportStrategyPayload {


### PR DESCRIPTION
Adds kalshiSubaccount field to CreateStrategyParams, UpdateStrategyParams, and Strategy response type. Also restores marketSlots to Strategy. All 436 tests pass.