### PR TITLE
fix(sdk): remove PUT from BatchRequestItem.method to match platform DTO (closes #235)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -937,7 +937,7 @@ export interface PaperSummary {
 
 export interface BatchRequestItem {
   id: string;
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   path: string;
   body?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Removes `PUT` from `BatchRequestItem.method` union type in `src/types.ts`
- The platform batch endpoint only accepts GET/POST/PATCH/DELETE
- Aligns with `ActionDefinition.method` which already had the correct union

## Verification
- Tests: 436 passed, 0 failures
- Typecheck: 0 errors

Closes #235