### PR TITLE
fix(sdk): stop unwrapping .data from 4 public user profile endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   `GET /api/v1/accuracy/leaderboard` (dedicated accuracy leaderboard) instead
   of `GET /api/v1/leaderboard` (P&L-ranked leaderboard). Test assertion
   updated to match. (closes #239)
+- **POLA-4628** — `getUserPerformance`, `getUserStrategies`, `getUserActivity`,
+  and `getUserBadgesByUsername` no longer unwrap `.data` from the platform
+  response; the platform now returns these arrays directly. Method signatures
+  already declared `Promise<T[]>`, so this is a transparent compatibility fix
+  with no SDK API surface change. (closes #238)
 - **POLA-3691 compatibility audit** — re-verified all 21 endpoint paths
   from GitHub issue #220 against platform NestJS controllers. All paths,
   methods, and controller prefixes already match the platform. No code

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -5227,10 +5227,10 @@ describe('Public user profile lookups', () => {
     fetchSpy?.mockRestore();
   });
 
-  it('getUserPerformance unwraps {data} and forwards period as a query param', async () => {
+  it('getUserPerformance returns bare array and forwards period as a query param', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({ data: [{ date: '2026-04-01', pnl: 12.5, cumPnl: 12.5 }] }),
+        JSON.stringify([{ date: '2026-04-01', pnl: 12.5, cumPnl: 12.5 }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5246,7 +5246,7 @@ describe('Public user profile lookups', () => {
 
   it('getUserPerformance defaults period to 30d', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserPerformance('bob');
@@ -5254,15 +5254,13 @@ describe('Public user profile lookups', () => {
     expect(url).toContain('period=30d');
   });
 
-  it('getUserStrategies unwraps {data} and forwards visibility/limit', async () => {
+  it('getUserStrategies returns bare array and forwards visibility/limit', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({
-          data: [{
-            id: 's1', name: 'Strat', description: 'd', winRate: 0,
-            tradeCount: 3, priceUsdc: 0, forkCount: 1, likeCount: 2, isLiked: false,
-          }],
-        }),
+        JSON.stringify([{
+          id: 's1', name: 'Strat', description: 'd', winRate: 0,
+          tradeCount: 3, priceUsdc: 0, forkCount: 1, likeCount: 2, isLiked: false,
+        }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5279,7 +5277,7 @@ describe('Public user profile lookups', () => {
 
   it('getUserStrategies omits query params when no options given', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserStrategies('alice');
@@ -5287,15 +5285,13 @@ describe('Public user profile lookups', () => {
     expect(new URL(url).search).toBe('');
   });
 
-  it('getUserActivity unwraps {data} and forwards limit', async () => {
+  it('getUserActivity returns bare array and forwards limit', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({
-          data: [{
-            id: 'p1', marketQuestion: 'Will it rain?', outcome: 'YES',
-            side: 'YES', size: 100, pnl: 5, resolvedAt: '2026-04-01T00:00:00.000Z',
-          }],
-        }),
+        JSON.stringify([{
+          id: 'p1', marketQuestion: 'Will it rain?', outcome: 'YES',
+          side: 'YES', size: 100, pnl: 5, resolvedAt: '2026-04-01T00:00:00.000Z',
+        }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5308,10 +5304,10 @@ describe('Public user profile lookups', () => {
     expect(result[0].id).toBe('p1');
   });
 
-  it('getUserBadgesByUsername unwraps {data}', async () => {
+  it('getUserBadgesByUsername returns bare array', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({ data: [{ id: 'EARLY_ADOPTER', unlockedAt: '2026-01-01T00:00:00.000Z' }] }),
+        JSON.stringify([{ id: 'EARLY_ADOPTER', unlockedAt: '2026-01-01T00:00:00.000Z' }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5355,7 +5351,7 @@ describe('Public user profile lookups', () => {
 
   it('username path segment is URL-encoded', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserBadgesByUsername('john doe');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1991,12 +1991,11 @@ export class PolyforgeClient {
     username: string,
     period: string = '30d',
   ): Promise<UserPerformancePoint[]> {
-    const res = await this.request<{ data: UserPerformancePoint[] }>(
+    return this.request<UserPerformancePoint[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/performance`,
       { query: { period } },
     );
-    return res.data;
   }
 
   /**
@@ -2010,12 +2009,11 @@ export class PolyforgeClient {
     const query: Record<string, string | number> = {};
     if (options.visibility !== undefined) query.visibility = options.visibility;
     if (options.limit !== undefined) query.limit = options.limit;
-    const res = await this.request<{ data: UserStrategySummary[] }>(
+    return this.request<UserStrategySummary[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/strategies`,
       Object.keys(query).length ? { query } : undefined,
     );
-    return res.data;
   }
 
   /**
@@ -2028,21 +2026,19 @@ export class PolyforgeClient {
   ): Promise<UserActivityEntry[]> {
     const query: Record<string, number> = {};
     if (options.limit !== undefined) query.limit = options.limit;
-    const res = await this.request<{ data: UserActivityEntry[] }>(
+    return this.request<UserActivityEntry[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/activity`,
       Object.keys(query).length ? { query } : undefined,
     );
-    return res.data;
   }
 
   /** Badges earned by a public user. */
   async getUserBadgesByUsername(username: string): Promise<UserProfileBadge[]> {
-    const res = await this.request<{ data: UserProfileBadge[] }>(
+    return this.request<UserProfileBadge[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/badges`,
     );
-    return res.data;
   }
 
   /** Paginated list of users the authenticated user follows. */


### PR DESCRIPTION
## Summary

`getUserPerformance`, `getUserStrategies`, `getUserActivity`, and `getUserBadgesByUsername` previously unwrapped `res.data` from a wrapped `{ data: T[] }` response, but the platform now returns bare arrays directly.

## Changes

- Removed `.data` unwrapping from all 4 methods in `src/client.ts`
- Updated tests to mock bare arrays instead of `{ data: [...] }`

## Verification

- 436 tests pass
- Typecheck clean (`tsc --noEmit`)
- Method signatures already declared `Promise<T[]>`, so no SDK API surface change

Closes #238