### PR TITLE
fix(sdk): stop unwrapping .data from 4 public user profile endpoints — platform now returns bare arrays (closes #238)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -5227,10 +5227,10 @@ describe('Public user profile lookups', () => {
     fetchSpy?.mockRestore();
   });
 
-  it('getUserPerformance unwraps {data} and forwards period as a query param', async () => {
+  it('getUserPerformance returns bare array and forwards period as a query param', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({ data: [{ date: '2026-04-01', pnl: 12.5, cumPnl: 12.5 }] }),
+        JSON.stringify([{ date: '2026-04-01', pnl: 12.5, cumPnl: 12.5 }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5246,7 +5246,7 @@ describe('Public user profile lookups', () => {
 
   it('getUserPerformance defaults period to 30d', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserPerformance('bob');
@@ -5254,15 +5254,13 @@ describe('Public user profile lookups', () => {
     expect(url).toContain('period=30d');
   });
 
-  it('getUserStrategies unwraps {data} and forwards visibility/limit', async () => {
+  it('getUserStrategies returns bare array and forwards visibility/limit', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({
-          data: [{
-            id: 's1', name: 'Strat', description: 'd', winRate: 0,
-            tradeCount: 3, priceUsdc: 0, forkCount: 1, likeCount: 2, isLiked: false,
-          }],
-        }),
+        JSON.stringify([{
+          id: 's1', name: 'Strat', description: 'd', winRate: 0,
+          tradeCount: 3, priceUsdc: 0, forkCount: 1, likeCount: 2, isLiked: false,
+        }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5279,7 +5277,7 @@ describe('Public user profile lookups', () => {
 
   it('getUserStrategies omits query params when no options given', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserStrategies('alice');
@@ -5287,15 +5285,13 @@ describe('Public user profile lookups', () => {
     expect(new URL(url).search).toBe('');
   });
 
-  it('getUserActivity unwraps {data} and forwards limit', async () => {
+  it('getUserActivity returns bare array and forwards limit', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({
-          data: [{
-            id: 'p1', marketQuestion: 'Will it rain?', outcome: 'YES',
-            side: 'YES', size: 100, pnl: 5, resolvedAt: '2026-04-01T00:00:00.000Z',
-          }],
-        }),
+        JSON.stringify([{
+          id: 'p1', marketQuestion: 'Will it rain?', outcome: 'YES',
+          side: 'YES', size: 100, pnl: 5, resolvedAt: '2026-04-01T00:00:00.000Z',
+        }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5308,10 +5304,10 @@ describe('Public user profile lookups', () => {
     expect(result[0].id).toBe('p1');
   });
 
-  it('getUserBadgesByUsername unwraps {data}', async () => {
+  it('getUserBadgesByUsername returns bare array', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
-        JSON.stringify({ data: [{ id: 'EARLY_ADOPTER', unlockedAt: '2026-01-01T00:00:00.000Z' }] }),
+        JSON.stringify([{ id: 'EARLY_ADOPTER', unlockedAt: '2026-01-01T00:00:00.000Z' }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
@@ -5355,7 +5351,7 @@ describe('Public user profile lookups', () => {
 
   it('username path segment is URL-encoded', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     );
 
     await client.getUserBadgesByUsername('john doe');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1991,12 +1991,12 @@ export class PolyforgeClient {
     username: string,
     period: string = '30d',
   ): Promise<UserPerformancePoint[]> {
-    const res = await this.request<{ data: UserPerformancePoint[] }>(
+    const res = await this.request<UserPerformancePoint[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/performance`,
       { query: { period } },
     );
-    return res.data;
+    return res;
   }
 
   /**
@@ -2010,12 +2010,12 @@ export class PolyforgeClient {
     const query: Record<string, string | number> = {};
     if (options.visibility !== undefined) query.visibility = options.visibility;
     if (options.limit !== undefined) query.limit = options.limit;
-    const res = await this.request<{ data: UserStrategySummary[] }>(
+    const res = await this.request<UserStrategySummary[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/strategies`,
       Object.keys(query).length ? { query } : undefined,
     );
-    return res.data;
+    return res;
   }
 
   /**
@@ -2028,21 +2028,21 @@ export class PolyforgeClient {
   ): Promise<UserActivityEntry[]> {
     const query: Record<string, number> = {};
     if (options.limit !== undefined) query.limit = options.limit;
-    const res = await this.request<{ data: UserActivityEntry[] }>(
+    const res = await this.request<UserActivityEntry[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/activity`,
       Object.keys(query).length ? { query } : undefined,
     );
-    return res.data;
+    return res;
   }
 
   /** Badges earned by a public user. */
   async getUserBadgesByUsername(username: string): Promise<UserProfileBadge[]> {
-    const res = await this.request<{ data: UserProfileBadge[] }>(
+    const res = await this.request<UserProfileBadge[]>(
       'GET',
       `/api/v1/users/${encodeURIComponent(username)}/badges`,
     );
-    return res.data;
+    return res;
   }
 
   /** Paginated list of users the authenticated user follows. */


### PR DESCRIPTION
## Summary
- `getUserPerformance`, `getUserStrategies`, `getUserActivity`, `getUserBadgesByUsername` were typed as `Promise<{ data: T[] }>` and returned `res.data`, but the platform's public-users controller methods return bare arrays directly.
- Fixed all 4 methods to use `Promise<T[]>` directly and return `res` instead of `res.data`.
- Updated all corresponding tests: changed mock responses from `{ data: [...] }` to `[...]` and renamed test descriptions from "unwraps {data}" to "returns bare array".

## Verification
- All 436 tests pass, including the 12 tests in the "Public user profile lookups" suite.

## Issue
Closes [#238](https://github.com/F4CTE/polyforge-sdk-ts/issues/238)

Co-Authored-By: Paperclip <noreply@paperclip.ing>