### PR TITLE
fix(sdk): make pnl, tradeCount, winRate optional in Strategy response type (closes #233)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,9 +83,9 @@ export interface Strategy {
   marketId?: string;
   marketSlots?: MarketSlot[];
   kalshiSubaccount?: number;
-  pnl: number;
-  tradeCount: number;
-  winRate: number;
+  pnl?: number;
+  tradeCount?: number;
+  winRate?: number;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

The platform no longer returns `pnl`, `tradeCount`, and `winRate` in strategy response payloads. Making these fields optional in the `Strategy` interface prevents type errors when consuming strategy data from the API.

## Changes

- `src/types.ts`: Changed `pnl`, `tradeCount`, `winRate` from required (`number`) to optional (`number?`) in the `Strategy` interface

## Verification

- All 436 tests pass