### PR TITLE
fix(sdk): add Idempotency-Key header to splitPosition and mergePosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,12 @@
   All four public-profile endpoints throw a `PolyforgeError` with `status: 404` / `code: "NOT_FOUND"` when the username does not exist. The `username` path segment is URL-encoded.
 
 ### Fixed
+- **`splitPosition` / `mergePosition` missing `Idempotency-Key` header** —
+  `splitPosition(params, idempotencyKey)` and `mergePosition(params, idempotencyKey)`
+  now accept a required `idempotencyKey: string` and pass the `Idempotency-Key`
+  header via `idempotencyHeaders()`, matching the pattern used by all other
+  protected write methods (`placeOrder`, `closePosition`, `executeArb`, etc.).
+  Regression of #208. (closes #231)
 - **BREAKING** `PlaceOrderParams`: remove `marketId` from direct order
   payloads to match the platform `PlaceOrderDto`; `placeOrder()` and
   `placeBatchOrders()` now strip legacy runtime `marketId` keys before

--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ Stop the stream at any time by calling `ac.abort()`. The generator will clean up
 | `placeBatchOrders(orders, idempotencyKey)` | Place multiple orders in one request |
 | `closePosition(params, idempotencyKey)` | Close an open position |
 | `redeemPosition(params, idempotencyKey)` | Redeem winning shares |
-| `splitPosition(params)` | Split a position |
-| `mergePosition(params)` | Merge positions |
+| `splitPosition(params, idempotencyKey)` | Split a position |
+| `mergePosition(params, idempotencyKey)` | Merge positions |
 | `cancelOrder(orderId)` | Cancel a pending or live order |
 
 Protected trading write methods require a caller-generated `idempotencyKey`
 between 8 and 128 characters. Reuse the same key when retrying the same request,
 and generate a new key for a different trading action. This applies to
 `placeOrder`, `placeBatchOrders`, `closePosition`, `redeemPosition`,
-`createConditionalOrder`, `placeSmartOrder`, `provideLiquidity`, `executeArb`,
-and `closeArbPosition`.
+`splitPosition`, `mergePosition`, `createConditionalOrder`, `placeSmartOrder`,
+`provideLiquidity`, `executeArb`, and `closeArbPosition`.
 
 ### Social & Signals
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3024,21 +3024,18 @@ describe('Trading write idempotency (#208)', () => {
         key,
       ),
     },
-  ];
-  const unprotectedPositionWrites = [
     {
       name: 'splitPosition',
       path: '/api/v1/orders/split',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: SplitPositionParams) => client.splitPosition(params),
+      call: (key: string) => client.splitPosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
     {
       name: 'mergePosition',
       path: '/api/v1/orders/merge',
-      params: { tokenId: 'tok-1', amount: '10' },
-      call: (params: MergePositionParams) => client.mergePosition(params),
+      call: (key: string) => client.mergePosition({ tokenId: 'tok-1', amount: '10' }, key),
     },
   ];
+  const unprotectedPositionWrites: { name: string; path: string; params: Record<string, string>; call: (...args: unknown[]) => Promise<unknown> }[] = [];
 
   it.each(tradingWrites)('$name sends Idempotency-Key on the protected POST endpoint', async ({ path, call }) => {
     await call('trade-key-123');
@@ -3093,7 +3090,7 @@ describe('Trading write idempotency (#208)', () => {
   });
 
   it.each(unprotectedPositionWrites)('$name ignores accidental extra key arguments instead of validating them', async ({ params, call }) => {
-    await (call as unknown as (requestParams: SplitPositionParams | MergePositionParams, key: string) => Promise<unknown>)(params, 'short');
+    await (call as unknown as (requestParams: SplitPositionParams | MergePositionParams, key: string) => Promise<unknown>)(params as unknown as SplitPositionParams, 'short');
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect((fetchSpy.mock.calls[0][1]!.headers as Record<string, string>)['Idempotency-Key']).toBeUndefined();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1552,19 +1552,29 @@ export class PolyforgeClient {
 
   /**
    * Split a position into smaller positions.
+   *
+   * Requires an `idempotencyKey` (8–128 chars). Pass a stable caller-generated
+   * key and reuse it when retrying the same split attempt. The key is sent as
+   * the `Idempotency-Key` header.
    */
-  async splitPosition(params: SplitPositionParams): Promise<PlaceOrderResponse> {
+  async splitPosition(params: SplitPositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/split', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 
   /**
    * Merge multiple positions into one.
+   *
+   * Requires an `idempotencyKey` (8–128 chars). Pass a stable caller-generated
+   * key and reuse it when retrying the same merge attempt. The key is sent as
+   * the `Idempotency-Key` header.
    */
-  async mergePosition(params: MergePositionParams): Promise<PlaceOrderResponse> {
+  async mergePosition(params: MergePositionParams, idempotencyKey: string): Promise<PlaceOrderResponse> {
     return this.request('POST', '/api/v1/orders/merge', {
       body: params,
+      headers: this.idempotencyHeaders(idempotencyKey),
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `idempotencyKey: string` parameter and `Idempotency-Key` header to `splitPosition` and `mergePosition`
- These two methods were missing idempotency key support — a regression of #208

## Changes
- **`src/client.ts`**: Added `idempotencyKey` parameter + `this.idempotencyHeaders()` header to both methods, matching pattern used by all other protected write methods
- **`src/__tests__/client.test.ts`**: Moved `splitPosition` and `mergePosition` from `unprotectedPositionWrites` to `tradingWrites` so they're covered by existing idempotency validation tests

## Verification
- 437 tests passing
- TypeScript typecheck clean (tsc --noEmit)
- Fix follows exact same pattern as `placeOrder`, `closePosition`, `executeArb`, `provideLiquidity`, and all other protected write methods

Closes #231