### PR TITLE
fix(sdk): listSmartOrders returns SmartOrder[] not PaginatedResponse (closes #234)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -242,6 +242,41 @@ describe('Platform contract compliance', () => {
     expect(body).not.toHaveProperty('intervalSeconds');
   });
 
+  it('listSmartOrders returns a bare SmartOrder[] not PaginatedResponse (#234)', async () => {
+    const payload: import('../types').SmartOrder[] = [
+      {
+        id: 'smart-1',
+        type: 'TWAP',
+        status: 'ACTIVE',
+        marketId: 'mkt-1',
+        tokenId: 'tok-1',
+        outcome: 'YES',
+        side: 'BUY',
+        totalSize: '100',
+        config: { slices: 5, intervalMinutes: 15 },
+        slicesFilled: 2,
+        slicesTotal: 5,
+        nextExecuteAt: '2026-05-14T18:00:00Z',
+        completedAt: null,
+        createdAt: '2026-05-14T17:00:00Z',
+        orders: [],
+      },
+    ];
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const result = await client.listSmartOrders();
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+
+    expect(new URL(url).pathname).toBe('/api/v1/orders/smart');
+    expect(init.method).toBe('GET');
+    expect(result).toEqual(payload);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0].id).toBe('smart-1');
+    expect(result[0].type).toBe('TWAP');
+  });
+
   it('WebhookEvent values use SCREAMING_SNAKE_CASE (#86)', async () => {
     // Type-level test: these should compile without error
     const events: import('../types').WebhookEvent[] = [

--- a/src/client.ts
+++ b/src/client.ts
@@ -1770,7 +1770,7 @@ export class PolyforgeClient {
   /**
    * List your smart orders with child order progress.
    */
-  async listSmartOrders(): Promise<PaginatedResponse<SmartOrder>> {
+  async listSmartOrders(): Promise<SmartOrder[]> {
     return this.request('GET', '/api/v1/orders/smart');
   }
 


### PR DESCRIPTION
## Summary

- Fixed `listSmartOrders()` return type: changed from `Promise<PaginatedResponse<SmartOrder>>` to `Promise<SmartOrder[]>`
- Added test verifying the method returns a bare array with correct endpoint and payload shape

## Root Cause

The platform endpoint `GET /api/v1/orders/smart` returns `prisma.smartOrder.findMany(...)` — a bare array with no pagination wrapper.

## Fix

- `src/client.ts`: Changed return type annotation
- `src/__tests__/client.test.ts`: Added test

## Verification

- TypeScript typecheck: passes
- All 437 tests pass (1 new test added, 0 removed)