### PR TITLE
fix(sdk): remove PUT from BatchRequestItem.method union (closes #235)

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2619,6 +2619,11 @@ describe('Batch API (#66)', () => {
     ];
     expect(validItems).toHaveLength(4);
     expect(new Set(validItems.map((i) => i.method))).toEqual(new Set(['GET', 'POST', 'PATCH', 'DELETE']));
+
+    // Type-level regression: PUT must NOT be accepted — @ts-expect-error fails if PUT is re-added
+    // @ts-expect-error: 'PUT' is not assignable to BatchRequestItem.method
+    const _putRejected: import('../types').BatchRequestItem = { id: 'rx', method: 'PUT', path: '/api/v1/test' };
+    void _putRejected;
   });
 });
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2608,6 +2608,18 @@ describe('Batch API (#66)', () => {
     expect(res.results[0].id).toBe('req-1');
     expect(res.results[1].id).toBe('req-2');
   });
+
+  it('BatchRequestItem.method excludes PUT — platform only accepts GET/POST/PATCH/DELETE (#235)', async () => {
+    // Type-level: these must compile
+    const validItems: import('../types').BatchRequestItem[] = [
+      { id: 'r1', method: 'GET', path: '/api/v1/test' },
+      { id: 'r2', method: 'POST', path: '/api/v1/test' },
+      { id: 'r3', method: 'PATCH', path: '/api/v1/test' },
+      { id: 'r4', method: 'DELETE', path: '/api/v1/test' },
+    ];
+    expect(validItems).toHaveLength(4);
+    expect(new Set(validItems.map((i) => i.method))).toEqual(new Set(['GET', 'POST', 'PATCH', 'DELETE']));
+  });
 });
 
 describe('Marketplace seller CRUD (#66)', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -943,7 +943,7 @@ export interface PaperSummary {
 
 export interface BatchRequestItem {
   id: string;
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   path: string;
   body?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

- Removed `PUT` from `BatchRequestItem.method` union type
- Added test verifying the method only accepts GET/POST/PATCH/DELETE

## Root Cause

Platform `BatchItemDto` uses `@IsIn(["GET", "POST", "PATCH", "DELETE"])` — PUT is not accepted. SDK incorrectly included PUT in the union.

## Fix

- `src/types.ts`: Removed `'PUT'` from the method union
- `src/__tests__/client.test.ts`: Added type-level test

## Verification

- TypeScript typecheck: passes
- All 437 tests pass (+1 new)