### PR TITLE
feat(sdk): add strategy health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Kalshi-backed sports markets, events, milestones, and combo lookups. Many respon
 |--------|-------------|
 | `listStrategies(params?)` | List your strategies, optionally filter by status |
 | `getStrategy(id)` | Get a strategy by ID |
+| `getStrategyHealth(id)` | Get execution health metrics for a strategy |
 | `createStrategy(params)` | Create a blank strategy |
 | `createStrategyFromDescription(params)` | AI-generate a strategy from natural language |
 | `startStrategy(id, mode?)` | Start a strategy (`'live'` or `'paper'`) |

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2276,6 +2276,32 @@ describe('Strategy social + versioning endpoints (#54)', () => {
     expect(url.pathname).toBe('/api/v1/strategies/s-1/event-log');
     expect(url.searchParams.has('limit')).toBe(false);
   });
+
+  it('getStrategyHealth sends GET /api/v1/strategies/:id/health', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          fillRate: null,
+          avgLatencyMs: 0,
+          errorCount24h: 0,
+          slippageBps: 0,
+          winRate: null,
+          totalPnl: null,
+          maxDrawdown: null,
+          totalOrders: 0,
+          filledOrders: 0,
+          lastUpdated: null,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const result = await client.getStrategyHealth('s-1');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.pathname).toBe('/api/v1/strategies/s-1/health');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+    expect(result.totalOrders).toBe(0);
+    expect(result.lastUpdated).toBeNull();
+  });
 });
 
 describe('SSE buffer size cap (#43)', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ import type {
   StrategyEvent,
   StrategyEventLogEntry,
   StrategyExport,
+  StrategyHealth,
   StrategyLikeResult,
   StrategyReportReason,
   StrategyReportResult,
@@ -739,6 +740,13 @@ export class PolyforgeClient {
    */
   async getStrategy(id: string): Promise<Strategy> {
     return this.request('GET', `/api/v1/strategies/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Get execution health metrics for a strategy.
+   */
+  async getStrategyHealth(id: string): Promise<StrategyHealth> {
+    return this.request('GET', `/api/v1/strategies/${encodeURIComponent(id)}/health`);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export type {
   StrategyEventType,
   StrategyExecMode,
   StrategyExport,
+  StrategyHealth,
   StrategyLikeResult,
   StrategyReportReason,
   StrategyReportResult,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,20 @@ export interface StrategyStatusResponse {
   stoppedAt?: string;
 }
 
+/** Execution health metrics for a strategy. */
+export interface StrategyHealth {
+  fillRate: number | null;
+  avgLatencyMs: number;
+  errorCount24h: number;
+  slippageBps: number;
+  winRate: number | null;
+  totalPnl: number | null;
+  maxDrawdown: number | null;
+  totalOrders: number;
+  filledOrders: number;
+  lastUpdated: string | null;
+}
+
 export interface StrategyTemplate {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- Add StrategyHealth response type matching GET /api/v1/strategies/:id/health
- Add PolyforgeClient.getStrategyHealth(id)
- Export the new type and document the method

## Verification
- npx vitest run src/__tests__/client.test.ts -t "getStrategyHealth sends" (red before implementation: client.getStrategyHealth is not a function; green after)
- npm run typecheck
- git diff --check
- npx vitest run src/__tests__/client.test.ts
- gitleaks git --redact --log-opts HEAD --no-banner
- GitNexus impact: PolyforgeClient LOW, StrategyEventLogEntry adjacent strategy type area LOW
- GitNexus detect_changes: low/no affected execution flows before commit; staged detect reported no indexed changes

Closes #269