### PR TITLE
feat: add strategy health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Kalshi-backed sports markets, events, milestones, and combo lookups. Many respon
 |--------|-------------|
 | `listStrategies(params?)` | List your strategies, optionally filter by status |
 | `getStrategy(id)` | Get a strategy by ID |
+| `getStrategyHealth(id)` | Get strategy execution health metrics |
 | `createStrategy(params)` | Create a blank strategy |
 | `createStrategyFromDescription(params)` | AI-generate a strategy from natural language |
 | `startStrategy(id, mode?)` | Start a strategy (`'live'` or `'paper'`) |

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
-import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, MarketSlot } from '../types';
+import type { StrategyStatusResponse, StrategyHealth, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, MarketSlot } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -225,6 +225,31 @@ describe('Platform contract compliance', () => {
     await client.startStrategy('strat-id', { mode: 'live', paperMode: true });
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
     expect(body).toEqual({ mode: 'live' });
+  });
+
+  it('getStrategyHealth sends GET /api/v1/strategies/:id/health (#269)', async () => {
+    const payload: StrategyHealth = {
+      fillRate: null,
+      avgLatencyMs: 0,
+      errorCount24h: 0,
+      slippageBps: 0,
+      winRate: null,
+      totalPnl: null,
+      maxDrawdown: null,
+      totalOrders: 0,
+      filledOrders: 0,
+      lastUpdated: null,
+    };
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const result = await client.getStrategyHealth('strat-id');
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+
+    expect(url.pathname).toBe('/api/v1/strategies/strat-id/health');
+    expect(fetchSpy.mock.calls[0][1]!.method).toBe('GET');
+    expect(result).toEqual(payload);
   });
 
   it('placeSmartOrder sends intervalMinutes not intervalSeconds (#88)', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,6 +67,7 @@ import type {
   StrategyEvent,
   StrategyEventLogEntry,
   StrategyExport,
+  StrategyHealth,
   StrategyLikeResult,
   StrategyReportReason,
   StrategyReportResult,
@@ -740,6 +741,13 @@ export class PolyforgeClient {
    */
   async getStrategy(id: string): Promise<Strategy> {
     return this.request('GET', `/api/v1/strategies/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Get execution health metrics for a strategy.
+   */
+  async getStrategyHealth(id: string): Promise<StrategyHealth> {
+    return this.request('GET', `/api/v1/strategies/${encodeURIComponent(id)}/health`);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export type {
   StrategyEventType,
   StrategyExecMode,
   StrategyExport,
+  StrategyHealth,
   StrategyLikeResult,
   StrategyReportReason,
   StrategyReportResult,

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,20 @@ export interface StrategyStatusResponse {
   stoppedAt?: string;
 }
 
+/** Execution health metrics for a strategy. */
+export interface StrategyHealth {
+  fillRate: number | null;
+  avgLatencyMs: number;
+  errorCount24h: number;
+  slippageBps: number;
+  winRate: number | null;
+  totalPnl: number | null;
+  maxDrawdown: number | null;
+  totalOrders: number;
+  filledOrders: number;
+  lastUpdated: string | null;
+}
+
 export interface StrategyTemplate {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add `StrategyHealth` type matching the platform `GET /api/v1/strategies/:id/health` payload
- expose `PolyforgeClient.getStrategyHealth(id)`
- document the new method and add endpoint contract coverage

Closes #269

## Verification
- `npm test -- --run src/__tests__/client.test.ts -t "getStrategyHealth"`
- `npm run typecheck`
- `npm test -- --run src/__tests__/client.test.ts`
- `git diff --check`
- added-line static security scan: no findings
- GitNexus pre-edit impact: LOW for `PolyforgeClient` and related strategy types
- GitNexus detect-changes before commit: low risk, no affected execution flows
- `npx gitnexus analyze` after commit: completed successfully

## Review notes
- Platform source checked in `services/api-service/src/strategies/strategies.controller.ts`; the SDK type mirrors the placeholder health response currently returned there.