### PR TITLE
fix: align ticket status type with platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Changed
+- **POLA-9875 compatibility fix** — `TicketStatus` now matches platform support
+  ticket states: `OPEN`, `AWAITING_USER`, `AWAITING_ADMIN`, and `CLOSED`.
 - **#234: `listSmartOrders` return type fixed** — changed from
   `Promise<PaginatedResponse<SmartOrder>>` to `Promise<SmartOrder[]>`. The
   platform's `GET /api/v1/orders/smart` returns a bare array, not a paginated

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
-import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, MarketSlot, SmartOrder } from '../types';
+import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, MarketSlot, SmartOrder, TicketStatus } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -3983,6 +3983,8 @@ describe('Support ticket endpoints (POLA-780)', () => {
   let client: PolyforgeClient;
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
+  const platformTicketStatuses: TicketStatus[] = ['OPEN', 'AWAITING_USER', 'AWAITING_ADMIN', 'CLOSED'];
+
   const mockTicket = {
     id: 'ticket-1', subject: 'Cannot withdraw funds', category: 'TECHNICAL',
     priority: 'HIGH', status: 'OPEN',
@@ -3998,6 +4000,10 @@ describe('Support ticket endpoints (POLA-780)', () => {
   });
 
   afterEach(() => { fetchSpy.mockRestore(); });
+
+  it('accepts all platform support ticket statuses', () => {
+    expect(platformTicketStatuses).toHaveLength(4);
+  });
 
   it('createTicket sends POST /api/v1/tickets with subject, body, category', async () => {
     fetchSpy.mockResolvedValueOnce(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1602,7 +1602,7 @@ export interface UpdateUserPreferencesParams {
 
 export type TicketCategory = 'GENERAL' | 'BILLING' | 'TECHNICAL' | 'ACCOUNT' | 'BUG' | 'FEATURE_REQUEST';
 export type TicketPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
-export type TicketStatus = 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
+export type TicketStatus = 'OPEN' | 'AWAITING_USER' | 'AWAITING_ADMIN' | 'CLOSED';
 
 export interface CreateTicketParams {
   subject: string;


### PR DESCRIPTION
## Summary
- Updates `TicketStatus` to match the platform-emitted support ticket states: `OPEN`, `AWAITING_USER`, `AWAITING_ADMIN`, and `CLOSED`.
- Adds a focused compile-time regression guard for the platform status set.
- Notes the compatibility fix in the changelog.

## Verification
- `npm test -- --run src/__tests__/client.test.ts` passed: 463 tests.
- `npm run typecheck` passed.
- `npm run build` passed.
- `git diff --check -- src/types.ts src/__tests__/client.test.ts CHANGELOG.md` passed.
- GitNexus index refreshed; impact for surrounding ticket methods `createTicket` and `listTickets` reported LOW risk with 0 direct callers and 0 affected processes. `TicketStatus` itself is not indexed as a symbol, and this CLI build does not expose `detect-changes`.

Closes #265