### PR TITLE
ci: allow manual SDK TS CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
## Summary
- Add workflow_dispatch to the SDK TS CI workflow so maintainers can manually trigger CI without close/reopen or empty-commit PR mutations.

## Context
- Supports POLA-10999 recovery for polyforge-sdk-ts PR #278, whose current head has CodeQL only and no CI Build & Test run.
- The source worktree could not stage this change because git metadata was outside the writable sandbox; this branch was published from a clean /tmp clone.

## Verification
- git diff --check -- .github/workflows/ci.yml
- node text check confirmed workflow_dispatch is directly under on:

Does not close POLA-10999; this only adds the non-disruptive trigger path for one remaining validation gap.