### PR TITLE
ci: allow manual validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
Adds workflow_dispatch to the SDK TS CI workflow so stranded PR heads with no pull_request-triggered CI run can be validated manually. This is the repo-local repair for POLA-10999 / POLA-10204 evidence where PR #278 head 0a87493143023919b406d259e0b31672a6c778b9 has CodeQL and argus status but no CI Build & Test run.