### PR TITLE
fix(sdk): voteMarketSentiment now sends required { direction, confidence } body (closes #261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Changed
+- **BREAKING** `voteMarketSentiment(marketId, params)` now sends the required
+  `{ direction, confidence }` JSON body for `POST /api/v1/markets/:marketId/sentiment`
+  instead of an empty request body. Adds `VoteMarketSentimentParams` and narrows
+  sentiment vote direction to `"YES" | "NO"`. (closes #261)
 - **#234: `listSmartOrders` return type fixed** — changed from
   `Promise<PaginatedResponse<SmartOrder>>` to `Promise<SmartOrder[]>`. The
   platform's `GET /api/v1/orders/smart` returns a bare array, not a paginated
@@ -86,7 +90,7 @@
   - `getMarketSentimentReport(marketId)` — `GET /api/v1/markets/:marketId/sentiment`
     (distinct from existing `getMarketSentiment()` which targets
     `/news/sentiment/:marketId`)
-  - `voteMarketSentiment(marketId)` — `POST /api/v1/markets/:marketId/sentiment`
+  - `voteMarketSentiment(marketId, params)` — `POST /api/v1/markets/:marketId/sentiment`
   - `updateOrderJournal(orderId, params)` — `PATCH /api/v1/orders/:id/journal`
   - `listComboCollections(params?)` — `GET /api/v1/markets/combo/collections`
   - `getComboCollection(ticker)` — `GET /api/v1/markets/combo/collections/:ticker`

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -4841,17 +4841,24 @@ describe('Misc public utility endpoints (POLA-1856)', () => {
     expect(result).toEqual(payload);
   });
 
-  it('voteMarketSentiment POSTs (no body) to /markets/:id/sentiment', async () => {
+  it('voteMarketSentiment POSTs { direction, confidence } to /markets/:id/sentiment', async () => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      jsonResponse({ yesPercent: 60, noPercent: 40, totalVotes: 5, userVote: null }),
+      jsonResponse({
+        yesPercent: 60,
+        noPercent: 40,
+        totalVotes: 5,
+        userVote: { direction: 'YES', confidence: 85 },
+      }),
     );
 
-    const result = await client.voteMarketSentiment('m1');
+    const result = await client.voteMarketSentiment('m1', { direction: 'YES', confidence: 85 });
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
 
     expect(init.method).toBe('POST');
     expect(url).toContain('/api/v1/markets/m1/sentiment');
+    expect(JSON.parse(init.body as string)).toEqual({ direction: 'YES', confidence: 85 });
     expect(result.yesPercent).toBe(60);
+    expect(result.userVote).toEqual({ direction: 'YES', confidence: 85 });
   });
 
   it('updateOrderJournal PATCHes /orders/:id/journal with mood + note', async () => {
@@ -4968,7 +4975,7 @@ describe('Misc public utility endpoints (POLA-1856)', () => {
     ['deleteMarketAlert', (c) => c.deleteMarketAlert('m1', 'a1')],
     ['getMarketHistory', (c) => c.getMarketHistory('m1')],
     ['getMarketSentimentReport', (c) => c.getMarketSentimentReport('m1')],
-    ['voteMarketSentiment', (c) => c.voteMarketSentiment('m1')],
+    ['voteMarketSentiment', (c) => c.voteMarketSentiment('m1', { direction: 'YES', confidence: 85 })],
     ['updateOrderJournal', (c) => c.updateOrderJournal('o1', { mood: 'CONFIDENT' })],
     ['listComboCollections', (c) => c.listComboCollections()],
     ['getComboCollection', (c) => c.getComboCollection('ghost')],

--- a/src/client.ts
+++ b/src/client.ts
@@ -169,6 +169,7 @@ import type {
   MarketHistoryPeriod,
   MarketHistory,
   MarketSentimentReport,
+  VoteMarketSentimentParams,
   ListComboCollectionsParams,
   ComboCollectionsPage,
   ComboCollection,
@@ -2309,11 +2310,15 @@ export class PolyforgeClient {
 
   /**
    * Cast a sentiment vote on a market. Returns the updated sentiment report.
-   * Note: the current controller treats POST as idempotent and returns the
-   * latest aggregate without persisting the user's vote.
+   * `direction` must be `YES` or `NO`; `confidence` must be an integer from 1 to 100.
    */
-  async voteMarketSentiment(marketId: string): Promise<MarketSentimentReport> {
-    return this.request('POST', `/api/v1/markets/${encodeURIComponent(marketId)}/sentiment`);
+  async voteMarketSentiment(
+    marketId: string,
+    params: VoteMarketSentimentParams,
+  ): Promise<MarketSentimentReport> {
+    return this.request('POST', `/api/v1/markets/${encodeURIComponent(marketId)}/sentiment`, {
+      body: params,
+    });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,8 @@ export type {
   MarketHistoryEntry,
   MarketHistory,
   MarketSentimentReport,
+  MarketSentimentVote,
+  VoteMarketSentimentParams,
   ListComboCollectionsParams,
   ComboCollection,
   ComboCollectionsPage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1987,12 +1987,26 @@ export interface MarketHistory {
   data: MarketHistoryEntry[];
 }
 
+export type MarketSentimentVoteDirection = 'YES' | 'NO';
+
+/** Request body for `POST /api/v1/markets/:marketId/sentiment`. */
+export interface VoteMarketSentimentParams {
+  direction: MarketSentimentVoteDirection;
+  confidence: number;
+}
+
+/** Authenticated user's vote inside a market sentiment report. */
+export interface MarketSentimentVote {
+  direction: MarketSentimentVoteDirection;
+  confidence: number;
+}
+
 /** Response shape for `GET /api/v1/markets/:marketId/sentiment`. */
 export interface MarketSentimentReport {
   yesPercent: number;
   noPercent: number;
   totalVotes: number;
-  userVote: { direction: string; confidence: number } | null;
+  userVote: MarketSentimentVote | null;
 }
 
 /** Query filter accepted by `GET /api/v1/markets/combo/collections`. */


### PR DESCRIPTION
## Summary

Closes [polyforge-sdk-ts#261](https://github.com/F4CTE/polyforge-sdk-ts/issues/261)

**Severity: Critical** — Every call to  returned HTTP 400 because the platform handler now requires a  body ().

## Changes

- **** — Added  and  interfaces; narrowed  to 
- **** — Updated  to accept  and pass it as request body; updated JSDoc
- **** — Updated tests with new signature
- **** — Documented breaking change

## Verification

- Test assertions verify body content and typed response
- Breaking change: signature changed from  to 