### PR TITLE
fix(sdk): checksum targetWallet via EIP-55 in createCopyConfig (POLA-9887)

### DIFF
--- a/src/__tests__/address.test.ts
+++ b/src/__tests__/address.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { eip55Checksum } from '../utils/address.js';
+
+describe('eip55Checksum', () => {
+  it('returns the known EIP-55 checksum for 0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', () => {
+    expect(eip55Checksum('0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed')).toBe(
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    );
+  });
+
+  it('preserves an address that is already EIP-55 checksummed', () => {
+    expect(eip55Checksum('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')).toBe(
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    );
+  });
+
+  it('lowercases addresses shorter than 40 hex chars', () => {
+    expect(eip55Checksum('0xAbC')).toBe('0xabc');
+    expect(eip55Checksum('0xABC')).toBe('0xabc');
+  });
+
+  it('strips 0x prefix regardless of case', () => {
+    expect(eip55Checksum('0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed')).toBe(
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    );
+    expect(eip55Checksum('5aaeb6053f3e94c9b9a09f33669435e7ef1beaed')).toBe(
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+    );
+  });
+
+  it('handles all-uppercase 40-char addresses', () => {
+    const upper = '0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED';
+    expect(eip55Checksum(upper)).toBe('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed');
+  });
+
+  it('handles mixed-case 40-char addresses', () => {
+    const mixed = '0x5AaEb6053f3E94c9B9a09F33669435E7ef1bEAeD';
+    expect(eip55Checksum(mixed)).toBe('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed');
+  });
+
+  it('lowercases addresses with wrong length (POLA-9887 compat)', () => {
+    expect(eip55Checksum('0x1234')).toBe('0x1234');
+    expect(eip55Checksum('0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed1')).toBe(
+      '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed1',
+    );
+  });
+});

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2380,6 +2380,20 @@ describe('Copy trading CRUD (#51)', () => {
     expect(body.mode).toBe('PERCENTAGE');
   });
 
+  it('createCopyConfig EIP-55 checksums targetWallet before sending the body (POLA-12488 supersedes POLA-9887)', async () => {
+    const params = {
+      targetWallet: '0xAbC123Def4567890aBC123dEf4567890ABc123dE',
+      mode: 'PERCENTAGE' as const,
+    };
+
+    await client.createCopyConfig(params);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    // EIP-55 checksummed form (POLA-12488 supersedes POLA-9887's .toLowerCase())
+    expect(body.targetWallet).toBe('0xabC123dEF4567890ABc123deF4567890aBC123De');
+    expect(params.targetWallet).toBe('0xAbC123Def4567890aBC123dEf4567890ABc123dE');
+  });
+
   it('getCopyConfig sends GET to /api/v1/copy/:id', async () => {
     await client.getCopyConfig('cfg-1');
     const url = new URL(fetchSpy.mock.calls[0][0] as string);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { isIPv4, isIPv6, isIP } from 'node:net';
 import { resolve4, resolve6 } from 'node:dns/promises';
 import { PolyforgeError } from './errors.js';
+import { eip55Checksum } from './utils/address.js';
 import type {
   AccuracyScore,
   AccuracyLeaderboardEntry,
@@ -1390,7 +1391,9 @@ export class PolyforgeClient {
 
   /** Create a new copy-trading configuration. */
   async createCopyConfig(params: CreateCopyConfigParams): Promise<CopyConfig> {
-    return this.request('POST', '/api/v1/copy', { body: params });
+    return this.request('POST', '/api/v1/copy', {
+      body: { ...params, targetWallet: eip55Checksum(params.targetWallet) },
+    });
   }
 
   /** Get a single copy-trading configuration by ID. */

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,40 @@
+import { keccak256 } from './keccak.js';
+
+/**
+ * EIP-55 checksummed address (with backwards-compatible fallback for short
+ * addresses).
+ *
+ * Full-length (40-hex-char) addresses are converted to the EIP-55 checksummed
+ * form using Keccak-256.  Shorter or otherwise non-standard addresses are
+ * simply lowercased – matching the legacy `.toLowerCase()` behaviour used by
+ * POLA-9887.
+ *
+ * Zero external dependencies – uses an inline keccak-f1600 permutation.
+ *
+ * Implementation matches ethers.js `getAddress`: iterates over 40 chars in
+ * pairs, checking high/low nibbles of the 32-byte Keccak-256 digest.
+ */
+export function eip55Checksum(address: string): string {
+  const raw = address.replace(/^0x/i, '');
+
+  // Non-standard length → fallback to lowercase (POLA-9887 compat)
+  if (raw.length !== 40) {
+    return '0x' + raw.toLowerCase();
+  }
+
+  // Hash the lowercase address bytes using Keccak-256 (original, not SHA3).
+  const hashBytes = keccak256(raw.toLowerCase());
+
+  // EIP-55: iterate over 40 address chars in pairs; each hash byte provides
+  // two nibbles (high nibble for char[i], low nibble for char[i+1]).
+  let result = '0x';
+  const lowerRaw = raw.toLowerCase();
+  for (let i = 0; i < 40; i++) {
+    const byteIdx = i >> 1;
+    const hashDigit = (i & 1) === 0 ? (hashBytes[byteIdx] >> 4) : (hashBytes[byteIdx] & 0x0f);
+    const char = lowerRaw[i];
+    result += hashDigit >= 8 ? char.toUpperCase() : char.toLowerCase();
+  }
+
+  return result;
+}

--- a/src/utils/keccak.ts
+++ b/src/utils/keccak.ts
@@ -1,0 +1,158 @@
+// Minimal Keccak-256 (keccak-f1600) implementation adapted from @noble/hashes.
+// Implements the original Keccak (not NIST SHA3) padding scheme.
+
+const U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
+const _32n = /* @__PURE__ */ BigInt(32);
+const _0n = /* @__PURE__ */ BigInt(0);
+const _1n = /* @__PURE__ */ BigInt(1);
+const _2n = /* @__PURE__ */ BigInt(2);
+const _7n = /* @__PURE__ */ BigInt(7);
+const _256n = /* @__PURE__ */ BigInt(256);
+const _0x71n = /* @__PURE__ */ BigInt(0x71);
+
+// Per-round constants (computed once)
+const [SHA3_PI, SHA3_ROTL, _SHA3_IOTA] = [[], [], []];
+for (let round = 0, R = _1n, x = 1, y = 0; round < 24; round++) {
+  [x, y] = [y, (2 * x + 3 * y) % 5];
+  SHA3_PI.push(2 * (5 * y + x));
+  SHA3_ROTL.push((((round + 1) * (round + 2)) / 2) % 64);
+  let t = _0n;
+  for (let j = 0; j < 7; j++) {
+    R = ((R << _1n) ^ ((R >> _7n) * _0x71n)) % _256n;
+    if (R & _2n) t ^= _1n << ((_1n << BigInt(j)) - _1n);
+  }
+  _SHA3_IOTA.push(t);
+}
+
+function fromBig(n: bigint, le = false): { h: number; l: number } {
+  if (le) return { h: Number(n & U32_MASK64), l: Number((n >> _32n) & U32_MASK64) };
+  return { h: Number((n >> _32n) & U32_MASK64) | 0, l: Number(n & U32_MASK64) | 0 };
+}
+
+function toBig(h: number, l: number): bigint {
+  return (BigInt(h >>> 0) << _32n) | BigInt(l >>> 0);
+}
+
+function split(lst: bigint[], le = false): [Uint32Array, Uint32Array] {
+  const Ah = new Uint32Array(lst.length);
+  const Al = new Uint32Array(lst.length);
+  for (let i = 0; i < lst.length; i++) {
+    const { h, l } = fromBig(lst[i], le);
+    [Ah[i], Al[i]] = [h, l];
+  }
+  return [Ah, Al];
+}
+
+function rotlSH(h: number, l: number, s: number): number {
+  return (h << s) | (l >>> (32 - s));
+}
+function rotlSL(h: number, l: number, s: number): number {
+  return (l << s) | (h >>> (32 - s));
+}
+function rotlBH(h: number, l: number, s: number): number {
+  return (l << (s - 32)) | (h >>> (64 - s));
+}
+function rotlBL(h: number, l: number, s: number): number {
+  return (h << (s - 32)) | (l >>> (64 - s));
+}
+
+function rotlH(h: number, l: number, s: number): number {
+  return s > 32 ? rotlBH(h, l, s) : rotlSH(h, l, s);
+}
+function rotlL(h: number, l: number, s: number): number {
+  return s > 32 ? rotlBL(h, l, s) : rotlSL(h, l, s);
+}
+
+// Split IOTA constants into high/low parts
+const [SHA3_IOTA_H, SHA3_IOTA_L] = split(_SHA3_IOTA, true);
+
+// keccak-f1600 permutation (24 rounds)
+function keccakP(s: Uint32Array, rounds = 24): void {
+  const B = new Uint32Array(5 * 2);
+  for (let round = 24 - rounds; round < 24; round++) {
+    // Theta
+    for (let x = 0; x < 10; x++)
+      B[x] = s[x] ^ s[x + 10] ^ s[x + 20] ^ s[x + 30] ^ s[x + 40];
+    for (let x = 0; x < 10; x += 2) {
+      const idx1 = (x + 8) % 10;
+      const idx0 = (x + 2) % 10;
+      const B0 = B[idx0];
+      const B1 = B[idx0 + 1];
+      const Th = rotlH(B0, B1, 1) ^ B[idx1];
+      const Tl = rotlL(B0, B1, 1) ^ B[idx1 + 1];
+      for (let y = 0; y < 50; y += 10) {
+        s[x + y] ^= Th;
+        s[x + y + 1] ^= Tl;
+      }
+    }
+    // Rho and Pi
+    let curH = s[2];
+    let curL = s[3];
+    for (let t = 0; t < 24; t++) {
+      const shift = SHA3_ROTL[t] as number;
+      const Th = rotlH(curH, curL, shift);
+      const Tl = rotlL(curH, curL, shift);
+      const PI = SHA3_PI[t] as number;
+      curH = s[PI];
+      curL = s[PI + 1];
+      s[PI] = Th;
+      s[PI + 1] = Tl;
+    }
+    // Chi
+    for (let y = 0; y < 50; y += 10) {
+      for (let x = 0; x < 10; x++) B[x] = s[y + x];
+      for (let x = 0; x < 10; x++)
+        s[y + x] ^= ~B[(x + 2) % 10] & B[(x + 4) % 10];
+    }
+    // Iota
+    s[0] ^= SHA3_IOTA_H[round];
+    s[1] ^= SHA3_IOTA_L[round];
+  }
+  B.fill(0);
+}
+
+/**
+ * Keccak-256 hash (original Keccak, not NIST SHA3).
+ * Uses the same padding as @noble/hashes keccak_256 (suffix=0x01, rate=136).
+ * Produces identical output to ethers.js getAddress checksum hash.
+ */
+export function keccak256(message: Uint8Array | string): Uint8Array {
+  const data = typeof message === 'string' ? new TextEncoder().encode(message) : message;
+  const state32 = new Uint32Array(200); // 1600 bits / 8 / 4 = 50 u64 = 100 u32 ... wait
+  // Actually state is 200 bytes = 50 u64 = 100 u32
+  const state = new Uint8Array(200);
+
+  // Copy data into state (XOR)
+  const rate = 136;
+  const blockLen = rate;
+  let pos = 0;
+  for (let i = 0; i < data.length; i++) {
+    state[pos++] ^= data[i];
+  }
+  // Suffix padding: XOR suffix (0x01) at position pos
+  state[pos] ^= 0x01;
+  // Final padding: XOR 0x80 at position blockLen-1
+  state[blockLen - 1] ^= 0x80;
+
+  // Convert 200-byte state to uint32 array for keccak-f1600.
+  // Noble stores each 64-bit lane as 2 consecutive uint32 values
+  // (low 32 bits, high 32 bits).  50 lanes × 2 = 100 uint32.
+  // Each uint32 reads 4 consecutive bytes from the state.
+  const s = new Uint32Array(50);
+  for (let i = 0; i < 200; i += 4) {
+    s[i / 4] = state[i] | (state[i + 1] << 8) | (state[i + 2] << 16) | (state[i + 3] << 24);
+  }
+
+  keccakP(s, 24);
+
+  // Convert back and extract first 32 bytes (256-bit digest).
+  for (let i = 0; i < 50; i++) {
+    const v = s[i];
+    state[i * 4] = v & 0xff;
+    state[i * 4 + 1] = (v >>> 8) & 0xff;
+    state[i * 4 + 2] = (v >>> 16) & 0xff;
+    state[i * 4 + 3] = (v >>> 24) & 0xff;
+  }
+
+  return state.slice(0, 32);
+}


### PR DESCRIPTION
## Summary

- **Issue**: [polyforge-sdk-ts#262](https://github.com/F4CTE/polyforge-sdk-ts/issues/262) / POLA-9887
- **Problem**: `createCopyConfig` forwards `targetWallet` to `POST /api/v1/copy` verbatim. The platform (POLA-3660) now requires EIP-55 valid casing. Mixed-case addresses that don't satisfy EIP-55 checksum are rejected with HTTP 400.
- **Fix**: Added zero-dependency `keccak-256` + `eip55Checksum()` utility. `createCopyConfig` now calls `eip55Checksum(params.targetWallet)` before sending.

## Files Changed

| File | Action |
|------|--------|
| `src/utils/keccak.ts` | **New** — Minimal Keccak-256 (keccak-f1600) implementation |
| `src/utils/address.ts` | **New** — `eip55Checksum()` using inline keccak |
| `src/client.ts` | Modified — `createCopyConfig` wraps `targetWallet` through `eip55Checksum()` |
| `src/__tests__/address.test.ts` | **New** — 7 unit tests for `eip55Checksum()` |
| `src/__tests__/client.test.ts` | Modified — E2E test for EIP-55 checksum in `createCopyConfig` |

## Verification

- All 470 tests pass (2 test files)
- `eip55Checksum()` verified against known EIP-55 test vector (`0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed`)
- Short-address fallback to `.toLowerCase()` preserves POLA-9887 compat

## Child Issue

- POLA-12489 (done) — tracks this fix implementation