### PR TITLE
fix(sdk): normalize webhook active/enabled payload compatibility

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1971,6 +1971,111 @@ describe('Webhook mutations (issue #57)', () => {
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.pathname).toContain('wh%2Fspecial%26id');
   });
+
+  it('normalizes listed webhook payloads to keep active and enabled coherent (#232)', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'wh-active-only',
+              url: 'https://example.com/hook',
+              events: ['ORDER_FILLED'],
+              secret: 'whsec_123',
+              active: true,
+              createdAt: '2026-06-01T00:00:00Z',
+            },
+            {
+              id: 'wh-stale-enabled',
+              url: 'https://example.com/stale',
+              events: ['ORDER_FILLED'],
+              secret: 'whsec_456',
+              active: false,
+              enabled: true,
+              createdAt: '2026-06-01T00:00:00Z',
+            },
+            {
+              id: 'wh-enabled-only',
+              url: 'https://example.com/legacy',
+              events: ['ORDER_FILLED'],
+              secret: 'whsec_789',
+              enabled: true,
+              createdAt: '2026-06-01T00:00:00Z',
+            },
+          ],
+          total: 3,
+          page: 1,
+          limit: 20,
+          totalPages: 1,
+          hasNext: false,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await client.listWebhooks();
+
+    expect(response.data[0]!.active).toBe(true);
+    expect(response.data[0]!.enabled).toBe(true);
+    expect(response.data[1]!.active).toBe(false);
+    expect(response.data[1]!.enabled).toBe(false);
+    expect(response.data[2]!.active).toBe(true);
+    expect(response.data[2]!.enabled).toBe(true);
+  });
+
+  it('normalizes created webhook payloads to include deprecated enabled compatibility field (#232)', async () => {
+    mockResolve4.mockResolvedValue(['93.184.216.34']);
+    mockResolve6.mockResolvedValue(['2606:2800:220:1:248:1893:25c8:1946']);
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'wh-2',
+          url: 'https://example.com/hook',
+          events: ['ORDER_FILLED'],
+          secret: 'whsec_456',
+          active: false,
+          createdAt: '2026-06-01T00:00:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await client.createWebhook({
+      url: 'https://example.com/hook',
+      events: ['ORDER_FILLED'],
+    });
+
+    expect(response.active).toBe(false);
+    expect(response.enabled).toBe(false);
+  });
+
+  it('normalizes created legacy enabled-only webhook payloads to definite active and enabled booleans (#232)', async () => {
+    mockResolve4.mockResolvedValue(['93.184.216.34']);
+    mockResolve6.mockResolvedValue(['2606:2800:220:1:248:1893:25c8:1946']);
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'wh-legacy',
+          url: 'https://example.com/hook',
+          events: ['ORDER_FILLED'],
+          secret: 'whsec_legacy',
+          enabled: true,
+          createdAt: '2026-06-01T00:00:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await client.createWebhook({
+      url: 'https://example.com/hook',
+      events: ['ORDER_FILLED'],
+    });
+
+    expect(response.active).toBe(true);
+    expect(response.enabled).toBe(true);
+  });
 });
 
 describe('Price history & order book (issue #52)', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -208,6 +208,11 @@ import type {
 } from './types.js';
 import { KNOWN_STRATEGY_EVENTS } from './types.js';
 
+type WebhookResponse = Omit<Webhook, 'active' | 'enabled'> & {
+  active?: boolean;
+  enabled?: boolean;
+};
+
 const DEFAULT_BASE_URL = 'https://api.polyforge.app';
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_STREAM_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours for long-lived SSE streams
@@ -1524,7 +1529,11 @@ export class PolyforgeClient {
    * List registered webhooks.
    */
   async listWebhooks(): Promise<PaginatedResponse<Webhook>> {
-    return this.request('GET', '/api/v1/webhooks');
+    const response = await this.request<PaginatedResponse<WebhookResponse>>('GET', '/api/v1/webhooks');
+    return {
+      ...response,
+      data: response.data.map((webhook) => this.normalizeWebhook(webhook)),
+    };
   }
 
   /**
@@ -1534,7 +1543,18 @@ export class PolyforgeClient {
     // Validate webhook URL to prevent SSRF attacks.
     // Resolves DNS to detect rebinding — see validateWebhookUrl() JSDoc.
     await validateWebhookUrl(params.url);
-    return this.request('POST', '/api/v1/webhooks', { body: params });
+    const response = await this.request<WebhookResponse>('POST', '/api/v1/webhooks', { body: params });
+    return this.normalizeWebhook(response);
+  }
+
+  private normalizeWebhook(webhook: WebhookResponse): Webhook {
+    const active = webhook.active ?? webhook.enabled ?? false;
+
+    return {
+      ...webhook,
+      active,
+      enabled: active,
+    };
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,6 +319,11 @@ export interface Webhook {
   events: WebhookEvent[];
   secret: string;
   active: boolean;
+  /**
+   * @deprecated Use `active` for webhook state. Kept for backward compatibility with
+   * clients that still read `enabled`.
+   */
+  enabled: boolean;
   lastDeliveredAt?: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Align webhook response typing with platform contract (`active` is now primary, `enabled` remains compatibility alias).
- Normalize webhook responses in `listWebhooks` and `createWebhook` so `enabled` mirrors `active`.
- Add regression tests for `active` -> `enabled` behavior on response normalization.

Closes #232