### PR TITLE
fix(sdk-ts): include offset and limit in getPolymarketActivity

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PolyforgeClient, isBlockedHost, validateWebhookUrl } from '../client';
 import { PolyforgeError } from '../errors';
 import { KNOWN_STRATEGY_EVENTS } from '../types';
-import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, StrategyCapabilities, StrategyDesignPatterns, StrategyExamples, MarketSlot, SmartOrder, TicketStatus, RealtimeServerEvent, CreateCopyConfigParams } from '../types';
+import type { StrategyStatusResponse, PaginatedResponse, Strategy, OrderStatus, StrategyStatus, Order, Position, ImportStrategyBlocks, ImportStrategyParams, PlaceOrderParams, ClosePositionParams, RedeemPositionParams, ProvideLiquidityParams, ConditionalOrderStatus, CreateAlertParams, CreateConditionalOrderParams, ConditionalOrder, CopyConfig, Alert, CopyMode, CopyStatus, ConditionalOrderType, OrderType, Market, Token, RunBacktestParams, CreateStrategyParams, TraderScore, WhaleTrade, NewsSignal, AiQueryResponse, SplitPositionParams, MergePositionParams, StrategyVisibility, StrategyExecMode, PortfolioPnlParams, PortfolioPnl, PriceHistoryEntry, PriceHistoryParams, OrderBook, AccuracyLeaderboardParams, SystemHealthPublic, SystemHealthAuthenticated, UserPreferences, UpdateUserPreferencesParams, ComboMarketLookup, ActionsSchema, StrategyCapabilities, StrategyDesignPatterns, StrategyExamples, MarketSlot, SmartOrder, TicketStatus, RealtimeServerEvent, CreateCopyConfigParams, GetPolymarketActivityParams } from '../types';
 
 // Mock node:dns/promises at the module level for ESM compatibility.
 vi.mock('node:dns/promises', () => ({
@@ -3535,6 +3535,54 @@ describe('Portfolio — Polymarket-specific (#156)', () => {
     await client.getPolymarketActivity('TRADE');
     const url = new URL(fetchSpy.mock.calls[0][0] as string);
     expect(url.searchParams.get('type')).toBe('TRADE');
+  });
+
+  it('getPolymarketActivity passes type, offset, and limit from params', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ activities: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await client.getPolymarketActivity({ type: 'TRADE', offset: 20, limit: 10 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('type')).toBe('TRADE');
+    expect(url.searchParams.get('offset')).toBe('20');
+    expect(url.searchParams.get('limit')).toBe('10');
+  });
+
+  it('getPolymarketActivity supports legacy type argument with pagination params', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ activities: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await client.getPolymarketActivity('TRADE', { offset: 40, limit: 20 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('type')).toBe('TRADE');
+    expect(url.searchParams.get('offset')).toBe('40');
+    expect(url.searchParams.get('limit')).toBe('20');
+  });
+
+  it('getPolymarketActivity preserves object params when pagination is forwarded separately', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ activities: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const params: GetPolymarketActivityParams = { type: 'TRADE' };
+    await client.getPolymarketActivity(params, { offset: 40, limit: 20 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.get('type')).toBe('TRADE');
+    expect(url.searchParams.get('offset')).toBe('40');
+    expect(url.searchParams.get('limit')).toBe('20');
+  });
+
+  it('getPolymarketActivity supports legacy optional type forwarding with pagination params', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ activities: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const type: string | undefined = undefined;
+    await client.getPolymarketActivity(type, { offset: 40, limit: 20 });
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.has('type')).toBe(false);
+    expect(url.searchParams.get('offset')).toBe('40');
+    expect(url.searchParams.get('limit')).toBe('20');
+  });
+
+  it('getPolymarketActivity supports optional object params forwarding', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ activities: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const params: GetPolymarketActivityParams | undefined = undefined;
+    await client.getPolymarketActivity(params);
+    const url = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(url.searchParams.has('type')).toBe(false);
+    expect(url.searchParams.has('offset')).toBe(false);
+    expect(url.searchParams.has('limit')).toBe(false);
   });
 
   it('getPolymarketActivity omits type param when not provided', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -981,19 +981,20 @@ export class PolyforgeClient {
    * - `getPolymarketActivity('TRADE')` — string filter (legacy)
    * - `getPolymarketActivity({ type: 'TRADE', offset: 0, limit: 20 })` — object params
    */
+  async getPolymarketActivity(type?: string, params?: Pick<GetPolymarketActivityParams, 'offset' | 'limit'>): Promise<{ activities: PolymarketActivity[] }>;
+  async getPolymarketActivity(params: GetPolymarketActivityParams): Promise<{ activities: PolymarketActivity[] }>;
+  async getPolymarketActivity(typeOrParams?: string | GetPolymarketActivityParams, params?: Pick<GetPolymarketActivityParams, 'offset' | 'limit'>): Promise<{ activities: PolymarketActivity[] }>;
   async getPolymarketActivity(
     typeOrParams?: string | GetPolymarketActivityParams,
+    params?: Pick<GetPolymarketActivityParams, 'offset' | 'limit'>,
   ): Promise<{ activities: PolymarketActivity[] }> {
-    if (typeof typeOrParams === 'string') {
-      return this.request('GET', '/api/v1/portfolio/polymarket/activity', {
-        query: { type: typeOrParams },
-      });
-    }
-    const params = typeOrParams ?? {};
+    const queryParams = typeof typeOrParams === 'string'
+      ? { ...params, type: typeOrParams }
+      : { ...(typeOrParams ?? {}), ...(params ?? {}) };
     const query: Record<string, unknown> = {};
-    if (params.type !== undefined) query.type = params.type;
-    if (params.offset !== undefined) query.offset = params.offset;
-    if (params.limit !== undefined) query.limit = params.limit;
+    if (queryParams.type !== undefined) query.type = queryParams.type;
+    if (queryParams.offset !== undefined) query.offset = queryParams.offset;
+    if (queryParams.limit !== undefined) query.limit = queryParams.limit;
     return this.request('GET', '/api/v1/portfolio/polymarket/activity', {
       query: Object.keys(query).length ? query : undefined,
     });


### PR DESCRIPTION
## Summary\n\nThis patch updates  to accept and forward pagination fields (, ) through to the platform endpoint, while preserving backward-compatible signature usage.\n\n## Changes\n- Add  type with , , and .\n- Update  overloads/query building to support both object params and legacy  argument.\n- Export new type from .\n- Add regression tests for object form and legacy string+pagination form.\n\n## Verification\n- 
> @polyforge/sdk@1.0.0 test /home/f4cte/polyforge-sdk-ts/.paperclip/worktrees/POLA-9790-polyforge-sdk-ts-273-compat-sdk-ts-getpolymarketactivity-missing-offset-and-limit-query-params-cannot-paginate
> vitest run "src/__tests__/client.test.ts"


 RUN  v3.2.4 /home/f4cte/polyforge-sdk-ts/.paperclip/worktrees/POLA-9790-polyforge-sdk-ts-273-compat-sdk-ts-getpolymarketactivity-missing-offset-and-limit-query-params-cannot-paginate

 ✓ src/__tests__/client.test.ts (464 tests) 137ms

 Test Files  1 passed (1)
      Tests  464 passed (464)
   Start at  08:37:51
   Duration  540ms (transform 207ms, setup 0ms, collect 226ms, tests 137ms, environment 0ms, prepare 42ms)\n\n## Reference\n- GitHub issue: https://github.com/F4CTE/polyforge-sdk-ts/issues/273\n- Paperclip issue: POLA-9790