### PR TITLE
docs: update copyright owner and package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 PolyForge Labs
+   Copyright 2026 Oryon Technologies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 PolyForge SDK TypeScript
-Copyright 2026 PolyForge Labs
+Copyright 2026 Oryon Technologies
 
 Licensed under the Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @polyforge/sdk
 
-Official TypeScript SDK for the **Polyforge** trading platform REST API. Zero dependencies -- uses the native `fetch` API available in Node.js 18+.
+Official TypeScript SDK for the **PolyForge** REST API, compatible with self-hosted and PolyForge Platform deployments. Zero dependencies -- uses the native `fetch` API available in Node.js 18+.
 
 ## Installation
 
@@ -204,4 +204,6 @@ Runs vitest for unit tests covering client instantiation, URL construction, and 
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE) for details.
+Copyright © 2026 Oryon Technologies.
+
+Licensed under Apache 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details.

--- a/package.json
+++ b/package.json
@@ -39,8 +39,16 @@
     "typescript",
     "rest-client"
   ],
-  "author": "Polyforge",
+  "author": "Oryon Technologies <dev@polyforge.app>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Polyforge-labs/PolyForge-sdk-ts.git"
+  },
+  "homepage": "https://polyforge.app",
+  "bugs": {
+    "url": "https://github.com/Polyforge-labs/PolyForge-sdk-ts/issues"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

- update copyright ownership from PolyForge Labs to Oryon Technologies
- clarify compatibility with self-hosted PolyForge and PolyForge Platform deployments
- add the current repository, homepage, and issue-tracker metadata
- retain the existing Apache 2.0 SDK licence

## Verification

- `npm ci`
- `npm run build`
- `npm test` — 511 tests passed
- `git diff --check` passed
- GitNexus staged analysis: low risk, 0 affected execution flows